### PR TITLE
fix: ensure that the enviroment context validation is actually a check to API context level

### DIFF
--- a/src/api/context.ts
+++ b/src/api/context.ts
@@ -261,12 +261,14 @@ export class ApiContext {
    */
   public get environmentContext(): { projId: string; envId: string } {
     if (
-      this._level !== ApiKeyLevel.ENVIRONMENT_LEVEL_API_KEY ||
+      this._contextLevel !== ApiContextLevel.ENVIRONMENT ||
       this._project === null ||
       this._environment === null
     ) {
       throw new PermitContextError(
-        `You cannot get environment context, current api context is: ${this._level.toString()}`,
+        `You cannot get environment context, current api context is: ${
+          ApiContextLevel[this._contextLevel]
+        }`,
       );
     }
     return {


### PR DESCRIPTION
This pull request includes an update to the `ApiContext` class within the `src/api/context.ts` file. The change primarily involves modifying the condition for retrieving the environment context and updating the error message to reflect the new context level.

### Changes to `ApiContext` class:

* Updated the condition to check `_contextLevel` instead of `_level` when determining the environment context. (`src/api/context.ts`, [src/api/context.tsL264-R271](diffhunk://#diff-a1b276cf28be065f7905a93c969700e3c86762339ce5c4aaafd11030ad542931L264-R271))
* Modified the error message to use `ApiContextLevel` for better clarity on the current API context. (`src/api/context.ts`, [src/api/context.tsL264-R271](diffhunk://#diff-a1b276cf28be065f7905a93c969700e3c86762339ce5c4aaafd11030ad542931L264-R271))