### PR TITLE
aligned the log message error anf the permit-api-error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea/*
 .nyc_output
+.env
 build
 node_modules
 test
@@ -13,3 +14,4 @@ src/openapi/.gitignore
 src/openapi/.npmignore
 src/openapi/.openapi-generator-ignore
 src/openapi/git_push.sh
+

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -7,12 +7,18 @@ import { BASE_PATH } from '../openapi/base';
 
 import { API_ACCESS_LEVELS, ApiContextLevel, ApiKeyLevel, PermitContextError } from './context';
 
+interface FormattedAxiosError {
+  code: string | undefined;
+  message: string;
+  error: any;
+  status: number | undefined;
+}
 export class PermitApiError<T> extends Error {
   constructor(message: string, public originalError: AxiosError<T>) {
     super(message);
   }
 
-  public get formattedAxiosError(): any {
+  public get formattedAxiosError(): FormattedAxiosError {
     return {
       code: this.originalError.code,
       message: this.message,

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -165,9 +165,11 @@ export abstract class BasePermitApi {
   protected handleApiError(err: unknown): never {
     if (axios.isAxiosError(err)) {
       // this is an http response with an error status code
-      const message = `Got error status code: ${err.response?.status}`;
+      const message = `Got error status code: ${err.response?.status}, err: ${JSON.stringify(
+        err?.response?.data,
+      )}`;
       // log this to the SDK logger
-      this.logger.error(`${message}, err: ${JSON.stringify(err?.response?.data)}`);
+      this.logger.error(message);
       // and throw a permit error exception
       throw new PermitApiError(message, err);
     } else {

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -12,6 +12,15 @@ export class PermitApiError<T> extends Error {
     super(message);
   }
 
+  public get formattedAxiosError(): any {
+    return {
+      code: this.originalError.code,
+      message: this.message,
+      error: this.originalError.response?.data,
+      status: this.originalError.status,
+    };
+  }
+
   public get request(): any {
     return this.originalError.request;
   }
@@ -165,13 +174,14 @@ export abstract class BasePermitApi {
   protected handleApiError(err: unknown): never {
     if (axios.isAxiosError(err)) {
       // this is an http response with an error status code
-      const message = `Got error status code: ${err.response?.status}, err: ${JSON.stringify(
+      const logMessage = `Got error status code: ${err.response?.status}, err: ${JSON.stringify(
         err?.response?.data,
       )}`;
+      const apiMessage = err.response?.data.message;
       // log this to the SDK logger
-      this.logger.error(message);
+      this.logger.error(logMessage);
       // and throw a permit error exception
-      throw new PermitApiError(message, err);
+      throw new PermitApiError(apiMessage, err);
     } else {
       // unexpected error, just throw
       throw err;


### PR DESCRIPTION
Updated Error Handling in Axios Responses
This update improves the error handling mechanism for Axios HTTP errors in the SDK by unifying the log message and the PermitApiError exception. Previously, the log message and the PermitApiError exception message were different, which could lead to confusion when debugging issues.

Key Changes:
The log message and the PermitApiError message are now the same.
Both messages contain the HTTP status code and the error response data, providing clearer and more consistent error reporting.
If an unexpected error occurs (non-Axios)
