### PR TITLE
Support include total count for listing roles and resources

### DIFF
--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -47,6 +47,30 @@ export interface IPagination {
   perPage?: number;
 }
 
+interface IBasePaginationExtended {
+  /**
+   * the page number to fetch (default: 1)
+   */
+  page?: number;
+  /**
+   * how many items to fetch per page (default: 100)
+   */
+  perPage?: number;
+  /**
+   * the total number of items
+   */
+  includeTotalCount?: boolean;
+}
+
+type IPaginationForceIncludeTotal = IBasePaginationExtended & { includeTotalCount: true };
+export type IPaginationExtended = IBasePaginationExtended | IPaginationForceIncludeTotal;
+
+export type ReturnPaginationType<
+  T extends IPaginationExtended,
+  Y,
+  Z,
+> = T extends IPaginationForceIncludeTotal ? Y : Z;
+
 export abstract class BasePermitApi {
   protected openapiClientConfig: Configuration;
   private scopeApi: APIKeysApi;

--- a/src/api/deprecated.ts
+++ b/src/api/deprecated.ts
@@ -179,9 +179,9 @@ export class DeprecatedApiClient extends BasePermitApi implements IDeprecatedPer
     await this.ensureContext(ApiContextLevel.ENVIRONMENT);
 
     try {
-      const response = await this._roles.listRoles({
+      const response = (await this._roles.listRoles({
         ...this.config.apiContext.environmentContext,
-      });
+      })) as AxiosResponse<RoleRead[]>;
 
       this.logger.debug(`[${response.status}] permit.api.listRoles()`);
       return response.data;

--- a/src/api/resources.ts
+++ b/src/api/resources.ts
@@ -128,7 +128,7 @@ export class ResourcesApi extends BasePermitApi implements IResourcesApi {
   /**
    * Retrieves a list of resources.
    *
-   * @param pagination The pagination options, @see {@link IBasePaginationExtended}
+   * @param pagination The pagination options, @see {@link IPaginationExtended}
    * @returns A promise that resolves to an array of resources.
    * @throws {@link PermitApiError} If the API returns an error HTTP status code.
    * @throws {@link PermitContextError} If the configured {@link ApiContext} does not match the required endpoint context.

--- a/src/openapi/api/resources-api.ts
+++ b/src/openapi/api/resources-api.ts
@@ -31,7 +31,7 @@ import {
 // @ts-ignore
 import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError } from '../base';
 // @ts-ignore
-import { HTTPValidationError } from '../types';
+import { HTTPValidationError, PaginatedResultResourceRead } from '../types';
 // @ts-ignore
 import { ResourceCreate } from '../types';
 // @ts-ignore
@@ -219,6 +219,7 @@ export const ResourcesApiAxiosParamCreator = function (configuration?: Configura
      * @param {boolean} [includeBuiltIn] Whether to include or exclude built-in resources, default is False
      * @param {number} [page] Page number of the results to fetch, starting at 1.
      * @param {number} [perPage] The number of results per page (max 100).
+     * @param {includeTotalCount} [includeTotalCount] Include the total count of resources in the response, default is False
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -228,6 +229,7 @@ export const ResourcesApiAxiosParamCreator = function (configuration?: Configura
       includeBuiltIn?: boolean,
       page?: number,
       perPage?: number,
+      includeTotalCount?: boolean,
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       // verify required parameter 'projId' is not null or undefined
@@ -262,6 +264,10 @@ export const ResourcesApiAxiosParamCreator = function (configuration?: Configura
 
       if (perPage !== undefined) {
         localVarQueryParameter['per_page'] = perPage;
+      }
+
+      if (includeTotalCount !== undefined) {
+        localVarQueryParameter['include_total_count'] = includeTotalCount;
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter);
@@ -492,6 +498,7 @@ export const ResourcesApiFp = function (configuration?: Configuration) {
      * @param {boolean} [includeBuiltIn] Whether to include or exclude built-in resources, default is False
      * @param {number} [page] Page number of the results to fetch, starting at 1.
      * @param {number} [perPage] The number of results per page (max 100).
+     * @param {includeTotalCount} [includeTotalCount] Include the total count of resources in the response, default is False
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -501,14 +508,21 @@ export const ResourcesApiFp = function (configuration?: Configuration) {
       includeBuiltIn?: boolean,
       page?: number,
       perPage?: number,
+      includeTotalCount?: boolean,
       options?: AxiosRequestConfig,
-    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<ResourceRead>>> {
+    ): Promise<
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<Array<ResourceRead> | PaginatedResultResourceRead>
+    > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.listResources(
         projId,
         envId,
         includeBuiltIn,
         page,
         perPage,
+        includeTotalCount,
         options,
       );
       return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
@@ -644,6 +658,7 @@ export const ResourcesApiFactory = function (
      * @param {boolean} [includeBuiltIn] Whether to include or exclude built-in resources, default is False
      * @param {number} [page] Page number of the results to fetch, starting at 1.
      * @param {number} [perPage] The number of results per page (max 100).
+     * @param {includeTotalCount} [includeTotalCount] Include the total count of resources in the response, default is False
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -653,10 +668,11 @@ export const ResourcesApiFactory = function (
       includeBuiltIn?: boolean,
       page?: number,
       perPage?: number,
+      includeTotalCount?: boolean,
       options?: any,
-    ): AxiosPromise<Array<ResourceRead>> {
+    ): AxiosPromise<Array<ResourceRead> | PaginatedResultResourceRead> {
       return localVarFp
-        .listResources(projId, envId, includeBuiltIn, page, perPage, options)
+        .listResources(projId, envId, includeBuiltIn, page, perPage, includeTotalCount, options)
         .then((request) => request(axios, basePath));
     },
     /**
@@ -828,6 +844,14 @@ export interface ResourcesApiListResourcesRequest {
    * @memberof ResourcesApiListResources
    */
   readonly perPage?: number;
+
+  /**
+   * Include total count in response
+   * @type {boolean}
+   * @memberof RolesApiListRoles
+   * @default false
+   */
+  readonly includeTotalCount?: boolean;
 }
 
 /**
@@ -992,6 +1016,7 @@ export class ResourcesApi extends BaseAPI {
         requestParameters.includeBuiltIn,
         requestParameters.page,
         requestParameters.perPage,
+        requestParameters.includeTotalCount,
         options,
       )
       .then((request) => request(this.axios, this.basePath));

--- a/src/openapi/api/roles-api.ts
+++ b/src/openapi/api/roles-api.ts
@@ -31,7 +31,7 @@ import {
 // @ts-ignore
 import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError } from '../base';
 // @ts-ignore
-import { AddRolePermissions } from '../types';
+import { AddRolePermissions, PaginatedResultRoleRead } from '../types';
 // @ts-ignore
 import { HTTPValidationError } from '../types';
 // @ts-ignore
@@ -342,6 +342,7 @@ export const RolesApiAxiosParamCreator = function (configuration?: Configuration
      * @param {string} envId Either the unique id of the environment, or the URL-friendly key of the environment (i.e: the \&quot;slug\&quot;).
      * @param {number} [page] Page number of the results to fetch, starting at 1.
      * @param {number} [perPage] The number of results per page (max 100).
+     * @param {boolean} [includeTotalCount] Include total count in response (default to false)
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -350,6 +351,7 @@ export const RolesApiAxiosParamCreator = function (configuration?: Configuration
       envId: string,
       page?: number,
       perPage?: number,
+      includeTotalCount?: boolean,
       options: AxiosRequestConfig = {},
     ): Promise<RequestArgs> => {
       // verify required parameter 'projId' is not null or undefined
@@ -366,9 +368,13 @@ export const RolesApiAxiosParamCreator = function (configuration?: Configuration
         baseOptions = configuration.baseOptions;
       }
 
-      const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options };
-      const localVarHeaderParameter = {} as any;
-      const localVarQueryParameter = {} as any;
+      const localVarRequestOptions: Record<string, unknown> = {
+        method: 'GET',
+        ...baseOptions,
+        ...options,
+      };
+      const localVarHeaderParameter: Record<string, unknown> = {};
+      const localVarQueryParameter: Record<string, unknown> = {};
 
       // authentication HTTPBearer required
       // http bearer authentication required
@@ -380,6 +386,10 @@ export const RolesApiAxiosParamCreator = function (configuration?: Configuration
 
       if (perPage !== undefined) {
         localVarQueryParameter['per_page'] = perPage;
+      }
+
+      if (includeTotalCount !== undefined) {
+        localVarQueryParameter['include_total_count'] = includeTotalCount;
       }
 
       setSearchParams(localVarUrlObj, localVarQueryParameter);
@@ -723,6 +733,7 @@ export const RolesApiFp = function (configuration?: Configuration) {
      * @param {string} envId Either the unique id of the environment, or the URL-friendly key of the environment (i.e: the \&quot;slug\&quot;).
      * @param {number} [page] Page number of the results to fetch, starting at 1.
      * @param {number} [perPage] The number of results per page (max 100).
+     * @param {boolean} [includeTotalCount] Include total count in response (default to false)
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
@@ -731,13 +742,20 @@ export const RolesApiFp = function (configuration?: Configuration) {
       envId: string,
       page?: number,
       perPage?: number,
+      includeTotalCount?: boolean,
       options?: AxiosRequestConfig,
-    ): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<RoleRead>>> {
+    ): Promise<
+      (
+        axios?: AxiosInstance,
+        basePath?: string,
+      ) => AxiosPromise<Array<RoleRead> | PaginatedResultRoleRead>
+    > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.listRoles(
         projId,
         envId,
         page,
         perPage,
+        includeTotalCount,
         options,
       );
       return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
@@ -939,7 +957,7 @@ export const RolesApiFactory = function (
       page?: number,
       perPage?: number,
       options?: any,
-    ): AxiosPromise<Array<RoleRead>> {
+    ): AxiosPromise<Array<RoleRead> | PaginatedResultRoleRead> {
       return localVarFp
         .listRoles(projId, envId, page, perPage, options)
         .then((request) => request(axios, basePath));
@@ -1197,6 +1215,14 @@ export interface RolesApiListRolesRequest {
    * @memberof RolesApiListRoles
    */
   readonly perPage?: number;
+
+  /**
+   * Include total count in response
+   * @type {boolean}
+   * @memberof RolesApiListRoles
+   * @default false
+   */
+  readonly includeTotalCount?: boolean;
 }
 
 /**
@@ -1424,6 +1450,7 @@ export class RolesApi extends BaseAPI {
         requestParameters.envId,
         requestParameters.page,
         requestParameters.perPage,
+        requestParameters.includeTotalCount,
         options,
       )
       .then((request) => request(this.axios, this.basePath));

--- a/src/tests/e2e/rbac.e2e.spec.ts
+++ b/src/tests/e2e/rbac.e2e.spec.ts
@@ -47,12 +47,20 @@ test('Permission check e2e test', async (t) => {
 
     // verify list output
     const resources = await permit.api.resources.list();
+    t.true(Array.isArray(resources));
     t.is(resources.length, 1);
     t.is(resources[0].id, document.id);
     t.is(resources[0].key, document.key);
     t.is(resources[0].name, document.name);
     t.is(resources[0].description, document.description);
     t.is(resources[0].urn, document.urn);
+
+    const resourcesWithTotalCount = await permit.api.resources.list({ includeTotalCount: true });
+    t.not(resourcesWithTotalCount, null);
+    t.not(resourcesWithTotalCount.data, null);
+    t.is(resourcesWithTotalCount.data.length, 1);
+    t.is(resourcesWithTotalCount.total_count, 1);
+    t.is(resourcesWithTotalCount.page_count, 1);
 
     // create admin role
     const admin = await permit.api.roles.create({
@@ -83,6 +91,10 @@ test('Permission check e2e test', async (t) => {
     t.is(viewer.description, 'an viewer role');
     t.not(viewer.permissions, undefined);
     t.is(viewer.permissions?.length, 0);
+
+    const roles = await permit.api.roles.list();
+    t.true(Array.isArray(roles));
+    t.is(roles.length, 2);
 
     // assign permissions to roles
     const assignedViewer = await permit.api.roles.assignPermissions('viewer', ['document:read']);
@@ -234,7 +246,12 @@ test('Permission check e2e test', async (t) => {
       await permit.api.roles.delete('viewer');
       await permit.api.resources.delete('document');
       t.is((await permit.api.resources.list()).length, 0);
-      t.is((await permit.api.roles.list()).length, 0);
+
+      const roles = await permit.api.roles.list();
+
+      t.true(Array.isArray(roles));
+      t.is(roles.length, 0);
+
       t.is((await permit.api.tenants.list()).length, 1); // the default tenant
       t.is((await permit.api.users.list()).data.length, 0);
     } catch (error) {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

add the possibility of listing resources with total count

- **What is the current behavior?** (You can also link to an open issue here)

no total count is available

- **What is the new behavior (if this is a feature change)?**

- **Other information**:

This pull request introduces enhancements to the pagination functionality in the API, particularly focusing on extending pagination options to include the total count of items. The changes span across multiple files and involve updates to interfaces, type definitions, and API methods.

### Pagination Enhancements:

* [`src/api/base.ts`](diffhunk://#diff-01abe3135c7df0c7fa5b2ab5f867610c495eee6880ae009cb83ac9cf3743ef51R50-R73): Added `IBasePaginationExtended` interface to include `page`, `perPage`, and `includeTotalCount` fields. Created `IPaginationExtended` type to support optional inclusion of total count.

### API Resource Changes:

* [`src/api/resources.ts`](diffhunk://#diff-f9c595d6803dfa64269907bd74d1fcf038e936291a82351aa092ed761740daf6R6-R31): Updated the `list` method in `ResourcesApi` to use the new `IPaginationExtended` type, allowing it to optionally include the total count of resources. [[1]](diffhunk://#diff-f9c595d6803dfa64269907bd74d1fcf038e936291a82351aa092ed761740daf6R6-R31) [[2]](diffhunk://#diff-f9c595d6803dfa64269907bd74d1fcf038e936291a82351aa092ed761740daf6L131-R143) [[3]](diffhunk://#diff-f9c595d6803dfa64269907bd74d1fcf038e936291a82351aa092ed761740daf6R152)
* [`src/openapi/api/resources-api.ts`](diffhunk://#diff-9c1f83f996bb6d4a04670ce98a63d6a8219c9ec6020491cfcab728e485c83b0cL34-R34): Modified functions and interfaces to support the `includeTotalCount` parameter in resource listing methods. [[1]](diffhunk://#diff-9c1f83f996bb6d4a04670ce98a63d6a8219c9ec6020491cfcab728e485c83b0cL34-R34) [[2]](diffhunk://#diff-9c1f83f996bb6d4a04670ce98a63d6a8219c9ec6020491cfcab728e485c83b0cR222) [[3]](diffhunk://#diff-9c1f83f996bb6d4a04670ce98a63d6a8219c9ec6020491cfcab728e485c83b0cR232) [[4]](diffhunk://#diff-9c1f83f996bb6d4a04670ce98a63d6a8219c9ec6020491cfcab728e485c83b0cR269-R272) [[5]](diffhunk://#diff-9c1f83f996bb6d4a04670ce98a63d6a8219c9ec6020491cfcab728e485c83b0cR501) [[6]](diffhunk://#diff-9c1f83f996bb6d4a04670ce98a63d6a8219c9ec6020491cfcab728e485c83b0cR511-R525) [[7]](diffhunk://#diff-9c1f83f996bb6d4a04670ce98a63d6a8219c9ec6020491cfcab728e485c83b0cR661) [[8]](diffhunk://#diff-9c1f83f996bb6d4a04670ce98a63d6a8219c9ec6020491cfcab728e485c83b0cR847-R854) [[9]](diffhunk://#diff-9c1f83f996bb6d4a04670ce98a63d6a8219c9ec6020491cfcab728e485c83b0cR1019)

### API Role Changes:

* [`src/api/roles.ts`](diffhunk://#diff-4cbc7a9f16b10152e1d472bf5d37d62e20f3b38017908d490c4199911cc50db8L4-R13): Updated the `list` method in `RolesApi` to use the new `IPaginationExtended` type, allowing it to optionally include the total count of roles. [[1]](diffhunk://#diff-4cbc7a9f16b10152e1d472bf5d37d62e20f3b38017908d490c4199911cc50db8L4-R13) [[2]](diffhunk://#diff-4cbc7a9f16b10152e1d472bf5d37d62e20f3b38017908d490c4199911cc50db8L16-R30) [[3]](diffhunk://#diff-4cbc7a9f16b10152e1d472bf5d37d62e20f3b38017908d490c4199911cc50db8L130-R151) [[4]](diffhunk://#diff-4cbc7a9f16b10152e1d472bf5d37d62e20f3b38017908d490c4199911cc50db8R160)
* [`src/openapi/api/roles-api.ts`](diffhunk://#diff-af24dc8cacb46251b5718895f09d759961b3a9a23bc4fade2654fc11dba04a41L34-R34): Modified functions and interfaces to support the `includeTotalCount` parameter in role listing methods. [[1]](diffhunk://#diff-af24dc8cacb46251b5718895f09d759961b3a9a23bc4fade2654fc11dba04a41L34-R34) [[2]](diffhunk://#diff-af24dc8cacb46251b5718895f09d759961b3a9a23bc4fade2654fc11dba04a41R345) [[3]](diffhunk://#diff-af24dc8cacb46251b5718895f09d759961b3a9a23bc4fade2654fc11dba04a41R354) [[4]](diffhunk://#diff-af24dc8cacb46251b5718895f09d759961b3a9a23bc4fade2654fc11dba04a41L369-R377) [[5]](diffhunk://#diff-af24dc8cacb46251b5718895f09d759961b3a9a23bc4fade2654fc11dba04a41R391-R394) [[6]](diffhunk://#diff-af24dc8cacb46251b5718895f09d759961b3a9a23bc4fade2654fc11dba04a41R736) [[7]](diffhunk://#diff-af24dc8cacb46251b5718895f09d759961b3a9a23bc4fade2654fc11dba04a41R745-R758) [[8]](diffhunk://#diff-af24dc8cacb46251b5718895f09d759961b3a9a23bc4fade2654fc11dba04a41L942-R960) [[9]](diffhunk://#diff-af24dc8cacb46251b5718895f09d759961b3a9a23bc4fade2654fc11dba04a41R1218-R1225)