### PR TITLE
export new types use in the list of resources and roles

### DIFF
--- a/src/api/resources.ts
+++ b/src/api/resources.ts
@@ -14,7 +14,13 @@ import { BASE_PATH } from '../openapi/base';
 import { BasePermitApi, IPaginationExtended, ReturnPaginationType } from './base';
 import { ApiContextLevel, ApiKeyLevel } from './context';
 
-export { ResourceCreate, ResourceRead, ResourceReplace, ResourceUpdate } from '../openapi';
+export {
+  ResourceCreate,
+  ResourceRead,
+  ResourceReplace,
+  ResourceUpdate,
+  PaginatedResultResourceRead,
+} from '../openapi';
 
 export interface IResourcesApi {
   /**

--- a/src/api/roles.ts
+++ b/src/api/roles.ts
@@ -13,7 +13,7 @@ import { BASE_PATH } from '../openapi/base';
 import { BasePermitApi, IPaginationExtended, ReturnPaginationType } from './base';
 import { ApiContextLevel, ApiKeyLevel } from './context';
 
-export { RoleCreate, RoleRead, RoleUpdate } from '../openapi';
+export { RoleCreate, RoleRead, RoleUpdate, PaginatedResultRoleRead } from '../openapi';
 
 export interface IRolesApi {
   /**


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Minor change. Export the newly use types

- **What is the current behavior?** (You can also link to an open issue here)
import from the wrong context

- **What is the new behavior (if this is a feature change)?**
Export directly from the api

- **Other information**:

This pull request includes updates to the API resource and role modules to support paginated results. The most important changes are the addition of `PaginatedResultResourceRead` and `PaginatedResultRoleRead` to the respective export lists.

Updates to support paginated results:

* [`src/api/resources.ts`](diffhunk://#diff-f9c595d6803dfa64269907bd74d1fcf038e936291a82351aa092ed761740daf6L17-R23): Added `PaginatedResultResourceRead` to the export list.
* [`src/api/roles.ts`](diffhunk://#diff-4cbc7a9f16b10152e1d472bf5d37d62e20f3b38017908d490c4199911cc50db8L16-R16): Added `PaginatedResultRoleRead` to the export list.