### PR TITLE
improve the error typing in the formatted axios error

### DIFF
--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -7,18 +7,18 @@ import { BASE_PATH } from '../openapi/base';
 
 import { API_ACCESS_LEVELS, ApiContextLevel, ApiKeyLevel, PermitContextError } from './context';
 
-interface FormattedAxiosError {
-  code: string | undefined;
+interface FormattedAxiosError<T> {
+  code?: string;
   message: string;
-  error: any;
-  status: number | undefined;
+  error?: T;
+  status?: number;
 }
 export class PermitApiError<T> extends Error {
   constructor(message: string, public originalError: AxiosError<T>) {
     super(message);
   }
 
-  public get formattedAxiosError(): FormattedAxiosError {
+  public get formattedAxiosError(): FormattedAxiosError<T> {
     return {
       code: this.originalError.code,
       message: this.message,


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Type changes

- **What is the current behavior?** (You can also link to an open issue here)
Error in the formatted axios error returns as any

- **What is the new behavior (if this is a feature change)?**
Gives explicit error type based on the provide T

- **Other information**:
This pull request includes a change to the `FormattedAxiosError` interface in the `src/api/base.ts` file to make it more flexible and type-safe.

Type improvements:

* [`src/api/base.ts`](diffhunk://#diff-01abe3135c7df0c7fa5b2ab5f867610c495eee6880ae009cb83ac9cf3743ef51L10-R21): Modified the `FormattedAxiosError` interface to be generic, allowing it to accept a type parameter `T` for the `error` property. Changed the `code` and `status` properties to be optional. Updated the `formattedAxiosError` getter in the `PermitApiError` class to use the generic `FormattedAxiosError<T>` type.