### PR TITLE
fix: rename esm to .mjs and add exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,16 +2,29 @@
   "name": "permitio",
   "version": "2.5.2",
   "description": "Node.js client library for the Permit.io full-stack permissions platform",
+  "type": "commonjs",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",
-  "module": "build/module/index.js",
-  "repository": "https://github.com/permitio/permit-node",
+  "module": "build/module/index.mjs",
+  "exports": {
+    ".": {
+      "types": "./build/module/index.d.ts",
+      "import": "./build/module/index.mjs",
+      "require": "./build/main/index.js"
+    },
+    "./build/main/*": "./build/main/*",
+    "./build/module/*": "./build/module/*"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/permitio/permit-node.git"
+  },
   "license": "MIT",
   "keywords": [],
   "scripts": {
     "build": "run-p build:*",
     "build:main": "tsc -p tsconfig.json",
-    "build:module": "tsc -p tsconfig.module.json",
+    "build:module": "tsc -p tsconfig.module.json && yarn rename:esm",
     "fix": "run-s fix:*",
     "fix:prettier": "prettier --config .prettierrc \"src/**/*.{ts,css,less,scss,js}\" --write",
     "fix:lint": "eslint src --ext .ts --fix",
@@ -33,6 +46,7 @@
     "docs": "typedoc",
     "docs:watch": "typedoc --watch",
     "version": "2.5.2",
+    "rename:esm": "/bin/zsh ./scripts/rename-mjs.sh",
     "reset-hard": "git clean -dfx && git reset --hard && yarn",
     "prepare": "npm run build && husky install",
     "prepare-release": "run-s reset-hard test cov:check doc:html version doc:publish",
@@ -119,5 +133,6 @@
     "exclude": [
       "**/*.spec.js"
     ]
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/scripts/rename-mjs.sh
+++ b/scripts/rename-mjs.sh
@@ -1,0 +1,4 @@
+for file in ./build/module/**/*.js; do
+  sed -i '' "s/\.js'/\.mjs'/g" "$file"
+  mv "$file" "${file%.js}.mjs"
+done


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
When consuming this package in a project with type=module (eg with Vite) node fails to resolve the esm version because the file extensions aren't .mjs. `"module": "file.js"` is also not officially supported by node, it should be defined using `exports`

 See: https://publint.dev/permitio@2.6.1

- **What is the new behavior (if this is a feature change)?**
ESM packages resolve the ESM build correctly. 

- **Other information**:
My colleague mentioned this on Slack already, I decided to open a PR for the changes.

Add a simple rename script that renames build/modules/**/*.js to .mjs.
Add exports field to package.json, which is supported since node 16.
Updated minor lint issues, add type="commonjs", add proper git repo link.
Added packageManager field for corepack support to make sure the correct package manager is used. (I'm using yarn 4, which would otherwise be used and break the lock file.)

I'm not sure if any consumers use imports from `permitio/build/*`, so i've added a wildcard to exports to make sure this is not a breaking change.