### PR TITLE
Add opt-in HTTP retry support (REST + PDP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ When enabled, the defaults are:
 >
 > - Retries are opt-in — providing a `retry` config object turns them on; omitting it (or passing `retry: false`) leaves them off.
 > - When enabled, PDP/OPA calls additionally retry `POST` because check operations are idempotent. The REST API does **not** retry `POST`, so non-idempotent writes are never repeated.
+> - A custom `axiosInstance` applies to the REST API only; PDP and OPA calls use dedicated internal axios instances.
 
 ### Customizing Retry Behavior
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,47 @@ npm install permitio
 3. Execute `yarn docs ; git add docs/ ; git commit -m "update tsdoc"` to update the auto generated docs
 4. Execute `yarn publish --access public`
 
+## Retry Configuration
+
+The SDK includes built-in retry support for transient failures. By default, retries are **enabled** with the following settings:
+
+- **3 retry attempts** with exponential backoff
+- Retries on network errors and status codes: `408`, `429`, `500`, `502`, `503`, `504`
+- Respects `Retry-After` headers for rate limiting (429)
+
+### Customizing Retry Behavior
+
+```typescript
+import { Permit } from 'permitio';
+
+// Use defaults (retry enabled)
+const permit = new Permit({ token: 'your-api-key' });
+
+// Custom retry configuration
+const permit = new Permit({
+  token: 'your-api-key',
+  retry: {
+    maxRetries: 5,
+    retryDelay: 500,        // Initial delay in ms
+    backoffMultiplier: 2,   // Exponential backoff multiplier
+    maxDelay: 30000,        // Maximum delay cap
+  },
+});
+
+// Disable retry entirely
+const permit = new Permit({
+  token: 'your-api-key',
+  retry: false,
+});
+
+// Different config for PDP vs REST API
+const permit = new Permit({
+  token: 'your-api-key',
+  retry: { maxRetries: 3 },
+  pdpRetry: { maxRetries: 5 },
+});
+```
+
 ## Documentation
 
 [Read the documentation at Permit.io website](https://docs.permit.io/sdk/nodejs/quickstart-nodejs#add-the-sdk-to-your-js-code)

--- a/README.md
+++ b/README.md
@@ -19,22 +19,30 @@ npm install permitio
 
 ## Retry Configuration
 
-The SDK includes built-in retry support for transient failures. By default, retries are **enabled** with the following settings:
+The SDK includes built-in retry support for transient failures. Retries are **opt-in**:
+they are **off** unless you pass a `retry` config (or `retry: { enabled: true }`).
+
+When enabled, the defaults are:
 
 - **3 retry attempts** with exponential backoff
 - Retries on network errors and status codes: `408`, `429`, `500`, `502`, `503`, `504`
 - Respects `Retry-After` headers for rate limiting (429)
+
+> **Behavioral note**
+>
+> - Retries are opt-in — providing a `retry` config object turns them on; omitting it (or passing `retry: false`) leaves them off.
+> - When enabled, PDP/OPA calls additionally retry `POST` because check operations are idempotent. The REST API does **not** retry `POST`, so non-idempotent writes are never repeated.
 
 ### Customizing Retry Behavior
 
 ```typescript
 import { Permit } from 'permitio';
 
-// Use defaults (retry enabled)
-const permit = new Permit({ token: 'your-api-key' });
+// Retries are off by default (opt-in)
+const permitDefault = new Permit({ token: 'your-api-key' });
 
-// Custom retry configuration
-const permit = new Permit({
+// Enable with custom retry configuration
+const permitCustom = new Permit({
   token: 'your-api-key',
   retry: {
     maxRetries: 5,
@@ -44,14 +52,14 @@ const permit = new Permit({
   },
 });
 
-// Disable retry entirely
-const permit = new Permit({
+// Explicitly disable retry
+const permitNoRetry = new Permit({
   token: 'your-api-key',
   retry: false,
 });
 
 // Different config for PDP vs REST API
-const permit = new Permit({
+const permitPdp = new Permit({
   token: 'your-api-key',
   retry: { maxRetries: 3 },
   pdpRetry: { maxRetries: 5 },

--- a/README.md
+++ b/README.md
@@ -24,9 +24,11 @@ they are **off** unless you pass a `retry` config (or `retry: { enabled: true }`
 
 When enabled, the defaults are:
 
-- **3 retry attempts** with exponential backoff
+- **3 retries** (up to 4 total attempts) with exponential backoff
 - Retries on network errors and status codes: `408`, `429`, `500`, `502`, `503`, `504`
 - Respects `Retry-After` headers for rate limiting (429)
+
+`maxRetries` is the number of retries _after_ the initial request, so the default of `3` means up to 4 total requests.
 
 > **Behavioral note**
 >

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   "dependencies": {
     "@bitauth/libauth": "^1.17.1",
     "axios": "^1.7.4",
+    "axios-retry": "^4.5.0",
     "lodash": "^4.17.21",
     "path-to-regexp": "^6.2.1",
     "pino": "8.11.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "fix:prettier": "prettier --config .prettierrc \"src/**/*.{ts,css,less,scss,js}\" --write",
     "fix:lint": "eslint src --ext .ts --fix",
     "test": "run-s test:*",
+    "test:unit": "run-s build && ava --verbose 'build/tests/unit/**/*.spec.js'",
     "test:integration": "run-s build && ava --verbose build/tests/endpoints/**/*.spec.js",
     "test:module-imports": "run-s build && ava --verbose build/tests/module-imports/**/*.spec.js",
     "test:e2e:rbac": "run-s build && ava --verbose build/tests/e2e/rbac.e2e.spec.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -84,6 +84,10 @@ export interface IPermitConfig {
    * an optional custom axios instance, to control the behavior of the HTTP client
    * used to connect to the Permit REST API.
    *
+   * This instance applies to the REST API only. PDP and OPA calls use dedicated
+   * internal axios instances, so their retry policy can differ and non-idempotent
+   * POST writes on the shared REST client are never retried.
+   *
    * @see https://axios-http.com/docs/instance
    * @see https://axios-http.com/docs/req_config
    */
@@ -104,8 +108,9 @@ export interface IPermitConfig {
    */
   factsSyncTimeoutPolicy: FactsSyncTimeoutPolicy | null;
   /**
-   * an optional custom axios instance for opa, to control the behavior of the HTTP client
-   * used to connect to the Permit REST API.
+   * an optional custom axios instance for OPA, to control the behavior of the HTTP
+   * client used to connect to OPA. This applies to OPA calls only and is separate
+   * from `axiosInstance` (REST API) and the dedicated internal PDP instance.
    *
    * @see https://axios-http.com/docs/instance
    * @see https://axios-http.com/docs/req_config
@@ -114,8 +119,9 @@ export interface IPermitConfig {
 
   /**
    * Configuration for automatic retry of failed requests.
-   * Set to false to disable retries entirely.
-   * Defaults to enabled with sensible defaults (3 retries, exponential backoff).
+   * Retries are opt-in: when omitted or set to false, retries are disabled.
+   * Providing a config object enables them (3 retries with exponential backoff
+   * by default).
    *
    * @see {@link IRetryConfig}
    */

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ import globalAxios, { AxiosInstance } from 'axios';
 import _ from 'lodash';
 
 import { ApiContext } from './api/context';
+import { IRetryConfig } from './utils/retry';
 import { RecursivePartial } from './utils/types';
 
 export type FactsSyncTimeoutPolicy = 'ignore' | 'fail';
@@ -110,6 +111,24 @@ export interface IPermitConfig {
    * @see https://axios-http.com/docs/req_config
    */
   opaAxiosInstance?: AxiosInstance;
+
+  /**
+   * Configuration for automatic retry of failed requests.
+   * Set to false to disable retries entirely.
+   * Defaults to enabled with sensible defaults (3 retries, exponential backoff).
+   *
+   * @see {@link IRetryConfig}
+   */
+  retry?: IRetryConfig | false;
+
+  /**
+   * Optional separate retry configuration for PDP (enforcement) calls.
+   * If not provided, uses the main `retry` configuration.
+   * Set to false to disable retries for PDP calls only.
+   *
+   * @see {@link IRetryConfig}
+   */
+  pdpRetry?: IRetryConfig | false;
 }
 
 /**

--- a/src/enforcement/enforcer.ts
+++ b/src/enforcement/enforcer.ts
@@ -5,6 +5,8 @@ import URL from 'url-parse';
 import { IPermitConfig } from '../config';
 import { CheckConfig, Context, ContextStore } from '../utils/context';
 import { AxiosLoggingInterceptor } from '../utils/http-logger';
+import { resolveRetryConfig } from '../utils/retry';
+import { AxiosRetryInterceptor } from '../utils/retry-interceptor';
 
 import {
   AllTenantsResponse,
@@ -163,6 +165,20 @@ export class Enforcer implements IEnforcer {
     }
     this.logger = logger;
     AxiosLoggingInterceptor.setupInterceptor(this.client, this.logger);
+
+    // Setup retry interceptors for PDP clients
+    // Use pdpRetry config if provided, otherwise fall back to main retry config
+    const pdpRetryConfig = resolveRetryConfig(config.pdpRetry ?? config.retry);
+    if (pdpRetryConfig.enabled) {
+      // For PDP calls, enable POST retry since check operations are idempotent
+      const pdpRetryWithPost = {
+        ...pdpRetryConfig,
+        retryMethods: [...pdpRetryConfig.retryMethods, 'POST'],
+      };
+      AxiosRetryInterceptor.setupInterceptor(this.client, pdpRetryWithPost, this.logger, 'PDP');
+      AxiosRetryInterceptor.setupInterceptor(this.opaClient, pdpRetryWithPost, this.logger, 'OPA');
+    }
+
     this.contextStore = new ContextStore();
   }
 

--- a/src/enforcement/enforcer.ts
+++ b/src/enforcement/enforcer.ts
@@ -139,18 +139,13 @@ export class Enforcer implements IEnforcer {
     opaBaseUrl.set('port', '8181');
     opaBaseUrl.set('pathname', `${opaBaseUrl.pathname}v1/data/permit/`);
     const version = process.env.npm_package_version ?? 'unknown';
-    if (config.axiosInstance) {
-      this.client = config.axiosInstance;
-      this.client.defaults.baseURL = `${this.config.pdp}/`;
-      this.client.defaults.headers.common['X-Permit-SDK-Version'] = `node:${version}`;
-    } else {
-      this.client = axios.create({
-        baseURL: `${this.config.pdp}/`,
-        headers: {
-          'X-Permit-SDK-Version': `node:${version}`,
-        },
-      });
-    }
+    // PDP gets its own dedicated axios instance so PDP-only POST retries never
+    // apply to the shared REST API client (config.axiosInstance) — REST writes
+    // must never be retried.
+    this.client = axios.create({
+      baseURL: `${this.config.pdp}/`,
+      headers: { 'X-Permit-SDK-Version': `node:${version}` },
+    });
     if (config.opaAxiosInstance) {
       this.opaClient = config.opaAxiosInstance;
       this.opaClient.defaults.baseURL = opaBaseUrl.toString();
@@ -173,7 +168,7 @@ export class Enforcer implements IEnforcer {
       // For PDP calls, enable POST retry since check operations are idempotent
       const pdpRetryWithPost = {
         ...pdpRetryConfig,
-        retryMethods: [...pdpRetryConfig.retryMethods, 'POST'],
+        retryMethods: [...new Set([...pdpRetryConfig.retryMethods, 'POST'])],
       };
       AxiosRetryInterceptor.setupInterceptor(this.client, pdpRetryWithPost, this.logger, 'PDP');
       AxiosRetryInterceptor.setupInterceptor(this.opaClient, pdpRetryWithPost, this.logger, 'OPA');

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,12 +143,19 @@ export class Permit implements IPermitClient {
     this.logger = LoggerFactory.createLogger(this.config);
     AxiosLoggingInterceptor.setupInterceptor(this.config.axiosInstance, this.logger);
 
-    // Setup retry interceptor for REST API calls
+    // Setup retry interceptor for REST API calls.
+    // Strip POST from the REST retryMethods regardless of user config: REST
+    // writes are non-idempotent and must never be repeated. (This is symmetric
+    // with the enforcer, which ADDS POST for the idempotent PDP/OPA check calls.)
     const resolvedRetryConfig = resolveRetryConfig(this.config.retry);
     if (resolvedRetryConfig.enabled) {
+      const restRetryConfig = {
+        ...resolvedRetryConfig,
+        retryMethods: resolvedRetryConfig.retryMethods.filter((m) => m !== 'POST'),
+      };
       AxiosRetryInterceptor.setupInterceptor(
         this.config.axiosInstance,
-        resolvedRetryConfig,
+        restRetryConfig,
         this.logger,
         'API',
       );

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,12 +27,7 @@ export { PermitConnectionError, PermitError, PermitPDPStatusError } from './enfo
 export { Context, ContextTransform } from './utils/context';
 export { ApiContext, PermitContextError, ApiKeyLevel } from './api/context';
 export { PermitApiError } from './api/base';
-export {
-  IRetryConfig,
-  RetryConditionFn,
-  RETRYABLE_STATUS_CODES,
-  NON_RETRYABLE_STATUS_CODES,
-} from './utils/retry';
+export { IRetryConfig, RetryConditionFn, RETRYABLE_STATUS_CODES } from './utils/retry';
 
 export interface IPermitClient extends IEnforcer {
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ import {
 import { LoggerFactory } from './logger';
 import { CheckConfig, Context } from './utils/context';
 import { AxiosLoggingInterceptor } from './utils/http-logger';
+import { resolveRetryConfig } from './utils/retry';
+import { AxiosRetryInterceptor } from './utils/retry-interceptor';
 import { RecursivePartial } from './utils/types';
 
 // exported interfaces
@@ -25,6 +27,12 @@ export { PermitConnectionError, PermitError, PermitPDPStatusError } from './enfo
 export { Context, ContextTransform } from './utils/context';
 export { ApiContext, PermitContextError, ApiKeyLevel } from './api/context';
 export { PermitApiError } from './api/base';
+export {
+  IRetryConfig,
+  RetryConditionFn,
+  RETRYABLE_STATUS_CODES,
+  NON_RETRYABLE_STATUS_CODES,
+} from './utils/retry';
 
 export interface IPermitClient extends IEnforcer {
   /**
@@ -139,6 +147,17 @@ export class Permit implements IPermitClient {
     this.config = ConfigFactory.build(config);
     this.logger = LoggerFactory.createLogger(this.config);
     AxiosLoggingInterceptor.setupInterceptor(this.config.axiosInstance, this.logger);
+
+    // Setup retry interceptor for REST API calls
+    const resolvedRetryConfig = resolveRetryConfig(this.config.retry);
+    if (resolvedRetryConfig.enabled) {
+      AxiosRetryInterceptor.setupInterceptor(
+        this.config.axiosInstance,
+        resolvedRetryConfig,
+        this.logger,
+        'API',
+      );
+    }
 
     this.api = new ApiClient(this.config, this.logger);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,11 +148,13 @@ export class Permit implements IPermitClient {
     // writes are non-idempotent and must never be repeated. (This is symmetric
     // with the enforcer, which ADDS POST for the idempotent PDP/OPA check calls.)
     const resolvedRetryConfig = resolveRetryConfig(this.config.retry);
-    if (resolvedRetryConfig.enabled) {
-      const restRetryConfig = {
-        ...resolvedRetryConfig,
-        retryMethods: resolvedRetryConfig.retryMethods.filter((m) => m !== 'POST'),
-      };
+    const restRetryConfig = {
+      ...resolvedRetryConfig,
+      retryMethods: resolvedRetryConfig.retryMethods.filter((m) => m !== 'POST'),
+    };
+    // Skip the install when no methods remain (e.g. retryMethods: ['POST']),
+    // which would otherwise add an interceptor that can never retry.
+    if (resolvedRetryConfig.enabled && restRetryConfig.retryMethods.length > 0) {
       AxiosRetryInterceptor.setupInterceptor(
         this.config.axiosInstance,
         restRetryConfig,

--- a/src/tests/unit/retry-interceptor.spec.ts
+++ b/src/tests/unit/retry-interceptor.spec.ts
@@ -34,6 +34,35 @@ function installRejectingAdapter(instance: AxiosInstance, status = 503): { count
   return { count: () => calls };
 }
 
+// Installs an adapter that rejects with a synthetic 503 for the first
+// `failTimes` calls, then resolves with a success response, so we can prove a
+// retry actually recovers.
+function installRejectThenResolveAdapter(
+  instance: AxiosInstance,
+  failTimes: number,
+): { count: () => number } {
+  let calls = 0;
+  instance.defaults.adapter = (config: InternalAxiosRequestConfig) => {
+    calls += 1;
+    if (calls <= failTimes) {
+      const error = new Error('synthetic failure') as AxiosError;
+      error.isAxiosError = true;
+      error.config = config;
+      error.toJSON = () => ({});
+      error.response = { status: 503, statusText: 'Error', headers: {}, config, data: {} };
+      return Promise.reject(error);
+    }
+    return Promise.resolve({
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config,
+      data: { ok: true },
+    });
+  };
+  return { count: () => calls };
+}
+
 async function newPermit(overrides: Record<string, unknown>): Promise<PermitInternals> {
   const { Permit } = await import('../../index');
   return new Permit({ token: 'test', ...overrides }) as unknown as PermitInternals;
@@ -125,6 +154,69 @@ test.serial('maps axios-retry retryCount to our 0-based attempt number', async (
     t.false(scheduledDelays.includes(90), 'attempt-1 (off-by-one) delay must not be used');
   } finally {
     Math.random = realRandom;
+    global.setTimeout = realSetTimeout;
+  }
+});
+
+test('a retry recovers: GET succeeds after one failed attempt', async (t) => {
+  const permit = await newPermit({
+    retry: { maxRetries: 2, retryDelay: 1, maxDelay: 5, backoffMultiplier: 1 },
+  });
+  const rest = installRejectThenResolveAdapter(permit.config.axiosInstance, 1);
+
+  const response = await permit.config.axiosInstance.request({ method: 'GET', url: '/x' });
+
+  // Initial failure + one retry that succeeds.
+  t.is(rest.count(), 2);
+  t.is(response.status, 200);
+  t.deepEqual(response.data, { ok: true });
+});
+
+test.serial('Retry-After header drives the retry delay end-to-end', async (t) => {
+  // 429 with `retry-after: 2` (seconds) must produce a 2000ms scheduled delay,
+  // which exceeds the 10ms backoff and is under maxDelay, proving Retry-After
+  // flows through calculateRetryDelay via our retryDelay callback. The
+  // Retry-After branch returns the exact value with no jitter, so we only need
+  // to capture the setTimeout delay (nothing is actually awaited).
+  const realSetTimeout = global.setTimeout;
+  const scheduledDelays: number[] = [];
+  global.setTimeout = ((fn: () => void, delay?: number): ReturnType<typeof setTimeout> => {
+    scheduledDelays.push(delay ?? 0);
+    return realSetTimeout(fn, 0);
+  }) as typeof setTimeout;
+  try {
+    const permit = await newPermit({
+      retry: { maxRetries: 1, retryDelay: 10, maxDelay: 30000, backoffMultiplier: 1 },
+    });
+
+    let calls = 0;
+    permit.config.axiosInstance.defaults.adapter = (
+      config: InternalAxiosRequestConfig,
+    ): Promise<never> => {
+      calls += 1;
+      const error = new Error('rate limited') as AxiosError;
+      error.isAxiosError = true;
+      error.config = config;
+      error.toJSON = () => ({});
+      error.response = {
+        status: 429,
+        statusText: 'Too Many Requests',
+        headers: { 'retry-after': '2' },
+        config,
+        data: {},
+      };
+      return Promise.reject(error);
+    };
+
+    await t.throwsAsync(() => permit.config.axiosInstance.request({ method: 'GET', url: '/x' }));
+
+    // 429 is retryable and GET is allowed, so it retried once.
+    t.is(calls, 2);
+    t.true(
+      scheduledDelays.includes(2000),
+      `expected a 2000ms delay, got ${scheduledDelays.join(',')}`,
+    );
+  } finally {
     global.setTimeout = realSetTimeout;
   }
 });

--- a/src/tests/unit/retry-interceptor.spec.ts
+++ b/src/tests/unit/retry-interceptor.spec.ts
@@ -1,9 +1,16 @@
 import test from 'ava';
-import { AxiosError, AxiosHeaders, AxiosInstance } from 'axios';
+import { AxiosError, AxiosHeaders, AxiosInstance, InternalAxiosRequestConfig } from 'axios';
 import { Logger } from 'pino';
 
 import { DEFAULT_RETRY_CONFIG, IResolvedRetryConfig } from '../../utils/retry';
 import { AxiosRetryInterceptor } from '../../utils/retry-interceptor';
+
+// Reaches the private REST (config.axiosInstance) and PDP (enforcer.client)
+// instances for the isolation regression tests below.
+interface PermitInternals {
+  config: { axiosInstance: AxiosInstance };
+  enforcer: { client: AxiosInstance };
+}
 
 // Minimal pino-like logger stub
 const warnings: string[] = [];
@@ -169,4 +176,72 @@ test('honors a Retry-After header and still retries', async (t) => {
 
   t.deepEqual(result, { ok: true });
   t.is(fake.requestCount, 1);
+});
+
+// ============================================
+// Isolation regression tests (CRITICAL + HIGH fixes)
+// ============================================
+
+// Installs a custom adapter that counts invocations and always rejects with a
+// synthetic 503 carrying the live request config, so the retry interceptor can
+// re-enter the chain via axiosInstance.request(...).
+function installRejectingAdapter(instance: AxiosInstance): { count: () => number } {
+  let calls = 0;
+  instance.defaults.adapter = (config: InternalAxiosRequestConfig): Promise<never> => {
+    calls += 1;
+    const error = new Error('synthetic failure') as AxiosError;
+    error.isAxiosError = true;
+    error.config = config;
+    error.toJSON = () => ({});
+    error.response = {
+      status: 503,
+      statusText: 'Service Unavailable',
+      headers: {},
+      config,
+      data: {},
+    };
+    return Promise.reject(error);
+  };
+  return { count: () => calls };
+}
+
+test('REST and PDP use separate axios instances', async (t) => {
+  const { Permit } = await import('../../index');
+
+  const permit = new Permit({
+    token: 'test',
+    retry: { maxRetries: 1 },
+    pdpRetry: { maxRetries: 1 },
+  });
+
+  const restInstance = (permit as unknown as PermitInternals).config.axiosInstance;
+  const pdpInstance = (permit as unknown as PermitInternals).enforcer.client;
+
+  t.not(restInstance, pdpInstance);
+});
+
+test('REST instance does not retry POST while PDP instance does', async (t) => {
+  const { Permit } = await import('../../index');
+
+  // Tiny delays keep the retry near-instant and deterministic.
+  const tiny = { maxRetries: 1, retryDelay: 1, maxDelay: 5, backoffMultiplier: 1 };
+  const permit = new Permit({
+    token: 'test',
+    retry: tiny,
+    pdpRetry: tiny,
+  });
+
+  const restInstance = (permit as unknown as PermitInternals).config.axiosInstance;
+  const pdpInstance = (permit as unknown as PermitInternals).enforcer.client;
+
+  const rest = installRejectingAdapter(restInstance);
+  const pdp = installRejectingAdapter(pdpInstance);
+
+  await t.throwsAsync(() => restInstance.request({ method: 'POST', url: '/x' }));
+  await t.throwsAsync(() => pdpInstance.request({ method: 'POST', url: '/x' }));
+
+  // REST never retries POST -> exactly one adapter call.
+  t.is(rest.count(), 1);
+  // PDP retries POST (maxRetries: 1) -> initial call + one retry = two.
+  t.is(pdp.count(), 2);
 });

--- a/src/tests/unit/retry-interceptor.spec.ts
+++ b/src/tests/unit/retry-interceptor.spec.ts
@@ -1,0 +1,172 @@
+import test from 'ava';
+import { AxiosError, AxiosHeaders, AxiosInstance } from 'axios';
+import { Logger } from 'pino';
+
+import { DEFAULT_RETRY_CONFIG, IResolvedRetryConfig } from '../../utils/retry';
+import { AxiosRetryInterceptor } from '../../utils/retry-interceptor';
+
+// Minimal pino-like logger stub
+const warnings: string[] = [];
+const loggerStub = {
+  warn: (msg: string): void => {
+    warnings.push(msg);
+  },
+} as unknown as Logger;
+
+// Fast, deterministic retry config built on top of the defaults.
+function fastConfig(overrides: Partial<IResolvedRetryConfig> = {}): IResolvedRetryConfig {
+  return {
+    ...DEFAULT_RETRY_CONFIG,
+    enabled: true,
+    retryDelay: 1,
+    maxDelay: 5,
+    backoffMultiplier: 1,
+    retryMethods: ['GET'],
+    ...overrides,
+  };
+}
+
+// Fake axios that captures the interceptor's rejection handler and models the
+// real interceptor chain: a failed retry re-enters the rejection handler with
+// the same (retry-count-carrying) request config, exactly like axios does.
+class FakeAxios {
+  public requestCount = 0;
+  public rejectionHandler!: (error: AxiosError) => Promise<unknown>;
+
+  // When set, request() fails by feeding the error back through the rejection
+  // handler so retry-count limiting is genuinely exercised. Otherwise it
+  // resolves, simulating a successful retry.
+  private failError: AxiosError | undefined;
+
+  public interceptors = {
+    response: {
+      use: (_onFulfilled: unknown, onRejected: (error: AxiosError) => Promise<unknown>): void => {
+        this.rejectionHandler = onRejected;
+      },
+    },
+  };
+
+  public request = (requestConfig: unknown): Promise<unknown> => {
+    this.requestCount += 1;
+    if (this.failError) {
+      // Re-drive the chain with the (mutated) config the interceptor passed in.
+      this.failError.config = requestConfig as AxiosError['config'];
+      return this.rejectionHandler(this.failError);
+    }
+    return Promise.resolve({ ok: true });
+  };
+
+  alwaysFail(error: AxiosError): void {
+    this.failError = error;
+  }
+
+  asInstance(): AxiosInstance {
+    return this as unknown as AxiosInstance;
+  }
+}
+
+function createError(method: string, status?: number, retryAfter?: string): AxiosError {
+  const error = new Error('Request failed') as AxiosError;
+  error.isAxiosError = true;
+  error.config = { method, url: '/test', headers: new AxiosHeaders() };
+  error.toJSON = () => ({});
+
+  if (status !== undefined) {
+    const headers: Record<string, string> = {};
+    if (retryAfter !== undefined) {
+      headers['retry-after'] = retryAfter;
+    }
+    error.response = {
+      status,
+      statusText: 'Error',
+      headers,
+      config: { headers: new AxiosHeaders() },
+      data: {},
+    };
+  }
+
+  return error;
+}
+
+function setup(config: IResolvedRetryConfig): FakeAxios {
+  const fake = new FakeAxios();
+  AxiosRetryInterceptor.setupInterceptor(fake.asInstance(), config, loggerStub, 'TEST');
+  return fake;
+}
+
+test('setupInterceptor does not register a handler when disabled', (t) => {
+  const fake = new FakeAxios();
+  AxiosRetryInterceptor.setupInterceptor(
+    fake.asInstance(),
+    fastConfig({ enabled: false }),
+    loggerStub,
+    'TEST',
+  );
+
+  t.is(fake.rejectionHandler, undefined);
+});
+
+test('retries a retryable GET until maxRetries then rejects with the original error', async (t) => {
+  const fake = setup(fastConfig({ maxRetries: 2 }));
+  const originalError = createError('GET', 503);
+  fake.alwaysFail(originalError);
+
+  const rejected = await t.throwsAsync(() => fake.rejectionHandler(originalError));
+
+  t.is(rejected, originalError);
+  // maxRetries=2 -> exactly two retry requests are issued before giving up.
+  t.is(fake.requestCount, 2);
+});
+
+test('retries a retryable GET and resolves on success', async (t) => {
+  const fake = setup(fastConfig({ maxRetries: 3 }));
+
+  const result = await fake.rejectionHandler(createError('GET', 503));
+
+  t.deepEqual(result, { ok: true });
+  t.is(fake.requestCount, 1);
+});
+
+test('does not retry a method outside retryMethods', async (t) => {
+  const fake = setup(fastConfig({ retryMethods: ['GET'] }));
+  const error = createError('POST', 503);
+
+  const rejected = await t.throwsAsync(() => fake.rejectionHandler(error));
+
+  t.is(rejected, error);
+  t.is(fake.requestCount, 0);
+});
+
+test('does not retry a non-retryable status code', async (t) => {
+  const fake = setup(fastConfig());
+  const error = createError('GET', 400);
+
+  const rejected = await t.throwsAsync(() => fake.rejectionHandler(error));
+
+  t.is(rejected, error);
+  t.is(fake.requestCount, 0);
+});
+
+test('rejects without retry when request config is missing', async (t) => {
+  const fake = setup(fastConfig());
+  const error = createError('GET', 503);
+  // Simulate axios giving us no config to retry with.
+  (error as { config?: unknown }).config = undefined;
+
+  const rejected = await t.throwsAsync(() => fake.rejectionHandler(error));
+
+  t.is(rejected, error);
+  t.is(fake.requestCount, 0);
+});
+
+test('honors a Retry-After header and still retries', async (t) => {
+  // "0" seconds keeps the delay immediate and the test deterministic; the
+  // delay-value math for Retry-After is covered in retry.spec.
+  const fake = setup(fastConfig({ respectRetryAfter: true, maxDelay: 50 }));
+  const error = createError('GET', 429, '0');
+
+  const result = await fake.rejectionHandler(error);
+
+  t.deepEqual(result, { ok: true });
+  t.is(fake.requestCount, 1);
+});

--- a/src/tests/unit/retry-interceptor.spec.ts
+++ b/src/tests/unit/retry-interceptor.spec.ts
@@ -1,191 +1,20 @@
 import test from 'ava';
-import { AxiosError, AxiosHeaders, AxiosInstance, InternalAxiosRequestConfig } from 'axios';
-import { Logger } from 'pino';
-
-import { DEFAULT_RETRY_CONFIG, IResolvedRetryConfig } from '../../utils/retry';
-import { AxiosRetryInterceptor } from '../../utils/retry-interceptor';
+import { AxiosError, AxiosInstance, InternalAxiosRequestConfig } from 'axios';
 
 // Reaches the private REST (config.axiosInstance) and PDP (enforcer.client)
-// instances for the isolation regression tests below.
+// instances for the behavior tests below.
 interface PermitInternals {
   config: { axiosInstance: AxiosInstance };
   enforcer: { client: AxiosInstance };
 }
 
-// Minimal pino-like logger stub
-const warnings: string[] = [];
-const loggerStub = {
-  warn: (msg: string): void => {
-    warnings.push(msg);
-  },
-} as unknown as Logger;
-
-// Fast, deterministic retry config built on top of the defaults.
-function fastConfig(overrides: Partial<IResolvedRetryConfig> = {}): IResolvedRetryConfig {
-  return {
-    ...DEFAULT_RETRY_CONFIG,
-    enabled: true,
-    retryDelay: 1,
-    maxDelay: 5,
-    backoffMultiplier: 1,
-    retryMethods: ['GET'],
-    ...overrides,
-  };
-}
-
-// Fake axios that captures the interceptor's rejection handler and models the
-// real interceptor chain: a failed retry re-enters the rejection handler with
-// the same (retry-count-carrying) request config, exactly like axios does.
-class FakeAxios {
-  public requestCount = 0;
-  public rejectionHandler!: (error: AxiosError) => Promise<unknown>;
-
-  // When set, request() fails by feeding the error back through the rejection
-  // handler so retry-count limiting is genuinely exercised. Otherwise it
-  // resolves, simulating a successful retry.
-  private failError: AxiosError | undefined;
-
-  public interceptors = {
-    response: {
-      use: (_onFulfilled: unknown, onRejected: (error: AxiosError) => Promise<unknown>): void => {
-        this.rejectionHandler = onRejected;
-      },
-    },
-  };
-
-  public request = (requestConfig: unknown): Promise<unknown> => {
-    this.requestCount += 1;
-    if (this.failError) {
-      // Re-drive the chain with the (mutated) config the interceptor passed in.
-      this.failError.config = requestConfig as AxiosError['config'];
-      return this.rejectionHandler(this.failError);
-    }
-    return Promise.resolve({ ok: true });
-  };
-
-  alwaysFail(error: AxiosError): void {
-    this.failError = error;
-  }
-
-  asInstance(): AxiosInstance {
-    return this as unknown as AxiosInstance;
-  }
-}
-
-function createError(method: string, status?: number, retryAfter?: string): AxiosError {
-  const error = new Error('Request failed') as AxiosError;
-  error.isAxiosError = true;
-  error.config = { method, url: '/test', headers: new AxiosHeaders() };
-  error.toJSON = () => ({});
-
-  if (status !== undefined) {
-    const headers: Record<string, string> = {};
-    if (retryAfter !== undefined) {
-      headers['retry-after'] = retryAfter;
-    }
-    error.response = {
-      status,
-      statusText: 'Error',
-      headers,
-      config: { headers: new AxiosHeaders() },
-      data: {},
-    };
-  }
-
-  return error;
-}
-
-function setup(config: IResolvedRetryConfig): FakeAxios {
-  const fake = new FakeAxios();
-  AxiosRetryInterceptor.setupInterceptor(fake.asInstance(), config, loggerStub, 'TEST');
-  return fake;
-}
-
-test('setupInterceptor does not register a handler when disabled', (t) => {
-  const fake = new FakeAxios();
-  AxiosRetryInterceptor.setupInterceptor(
-    fake.asInstance(),
-    fastConfig({ enabled: false }),
-    loggerStub,
-    'TEST',
-  );
-
-  t.is(fake.rejectionHandler, undefined);
-});
-
-test('retries a retryable GET until maxRetries then rejects with the original error', async (t) => {
-  const fake = setup(fastConfig({ maxRetries: 2 }));
-  const originalError = createError('GET', 503);
-  fake.alwaysFail(originalError);
-
-  const rejected = await t.throwsAsync(() => fake.rejectionHandler(originalError));
-
-  t.is(rejected, originalError);
-  // maxRetries=2 -> exactly two retry requests are issued before giving up.
-  t.is(fake.requestCount, 2);
-});
-
-test('retries a retryable GET and resolves on success', async (t) => {
-  const fake = setup(fastConfig({ maxRetries: 3 }));
-
-  const result = await fake.rejectionHandler(createError('GET', 503));
-
-  t.deepEqual(result, { ok: true });
-  t.is(fake.requestCount, 1);
-});
-
-test('does not retry a method outside retryMethods', async (t) => {
-  const fake = setup(fastConfig({ retryMethods: ['GET'] }));
-  const error = createError('POST', 503);
-
-  const rejected = await t.throwsAsync(() => fake.rejectionHandler(error));
-
-  t.is(rejected, error);
-  t.is(fake.requestCount, 0);
-});
-
-test('does not retry a non-retryable status code', async (t) => {
-  const fake = setup(fastConfig());
-  const error = createError('GET', 400);
-
-  const rejected = await t.throwsAsync(() => fake.rejectionHandler(error));
-
-  t.is(rejected, error);
-  t.is(fake.requestCount, 0);
-});
-
-test('rejects without retry when request config is missing', async (t) => {
-  const fake = setup(fastConfig());
-  const error = createError('GET', 503);
-  // Simulate axios giving us no config to retry with.
-  (error as { config?: unknown }).config = undefined;
-
-  const rejected = await t.throwsAsync(() => fake.rejectionHandler(error));
-
-  t.is(rejected, error);
-  t.is(fake.requestCount, 0);
-});
-
-test('honors a Retry-After header and still retries', async (t) => {
-  // "0" seconds keeps the delay immediate and the test deterministic; the
-  // delay-value math for Retry-After is covered in retry.spec.
-  const fake = setup(fastConfig({ respectRetryAfter: true, maxDelay: 50 }));
-  const error = createError('GET', 429, '0');
-
-  const result = await fake.rejectionHandler(error);
-
-  t.deepEqual(result, { ok: true });
-  t.is(fake.requestCount, 1);
-});
-
-// ============================================
-// Isolation regression tests (CRITICAL + HIGH fixes)
-// ============================================
+// Tiny delays keep every retry near-instant and deterministic (no real waits).
+const tiny = { maxRetries: 2, retryDelay: 1, maxDelay: 5, backoffMultiplier: 1 };
 
 // Installs a custom adapter that counts invocations and always rejects with a
-// synthetic 503 carrying the live request config, so the retry interceptor can
-// re-enter the chain via axiosInstance.request(...).
-function installRejectingAdapter(instance: AxiosInstance): { count: () => number } {
+// synthetic AxiosError carrying the live request config, so axios-retry can
+// re-dispatch the request and we can observe how many times it ran.
+function installRejectingAdapter(instance: AxiosInstance, status = 503): { count: () => number } {
   let calls = 0;
   instance.defaults.adapter = (config: InternalAxiosRequestConfig): Promise<never> => {
     calls += 1;
@@ -194,8 +23,8 @@ function installRejectingAdapter(instance: AxiosInstance): { count: () => number
     error.config = config;
     error.toJSON = () => ({});
     error.response = {
-      status: 503,
-      statusText: 'Service Unavailable',
+      status,
+      statusText: 'Error',
       headers: {},
       config,
       data: {},
@@ -205,43 +34,97 @@ function installRejectingAdapter(instance: AxiosInstance): { count: () => number
   return { count: () => calls };
 }
 
-test('REST and PDP use separate axios instances', async (t) => {
+async function newPermit(overrides: Record<string, unknown>): Promise<PermitInternals> {
   const { Permit } = await import('../../index');
+  return new Permit({ token: 'test', ...overrides }) as unknown as PermitInternals;
+}
 
-  const permit = new Permit({
-    token: 'test',
-    retry: { maxRetries: 1 },
-    pdpRetry: { maxRetries: 1 },
-  });
+test('REST and PDP use separate axios instances', async (t) => {
+  const permit = await newPermit({ retry: { maxRetries: 1 }, pdpRetry: { maxRetries: 1 } });
 
-  const restInstance = (permit as unknown as PermitInternals).config.axiosInstance;
-  const pdpInstance = (permit as unknown as PermitInternals).enforcer.client;
-
-  t.not(restInstance, pdpInstance);
+  t.not(permit.config.axiosInstance, permit.enforcer.client);
 });
 
 test('REST instance does not retry POST while PDP instance does', async (t) => {
-  const { Permit } = await import('../../index');
+  const permit = await newPermit({ retry: tiny, pdpRetry: tiny });
 
-  // Tiny delays keep the retry near-instant and deterministic.
-  const tiny = { maxRetries: 1, retryDelay: 1, maxDelay: 5, backoffMultiplier: 1 };
-  const permit = new Permit({
-    token: 'test',
-    retry: tiny,
-    pdpRetry: tiny,
-  });
+  const rest = installRejectingAdapter(permit.config.axiosInstance);
+  const pdp = installRejectingAdapter(permit.enforcer.client);
 
-  const restInstance = (permit as unknown as PermitInternals).config.axiosInstance;
-  const pdpInstance = (permit as unknown as PermitInternals).enforcer.client;
-
-  const rest = installRejectingAdapter(restInstance);
-  const pdp = installRejectingAdapter(pdpInstance);
-
-  await t.throwsAsync(() => restInstance.request({ method: 'POST', url: '/x' }));
-  await t.throwsAsync(() => pdpInstance.request({ method: 'POST', url: '/x' }));
+  await t.throwsAsync(() => permit.config.axiosInstance.request({ method: 'POST', url: '/x' }));
+  await t.throwsAsync(() => permit.enforcer.client.request({ method: 'POST', url: '/x' }));
 
   // REST never retries POST -> exactly one adapter call.
   t.is(rest.count(), 1);
-  // PDP retries POST (maxRetries: 1) -> initial call + one retry = two.
-  t.is(pdp.count(), 2);
+  // PDP retries POST (maxRetries: 2) -> initial call + two retries = three.
+  t.is(pdp.count(), 3);
+});
+
+test('a retryable GET retries up to maxRetries then rejects', async (t) => {
+  const permit = await newPermit({ retry: tiny });
+  const rest = installRejectingAdapter(permit.config.axiosInstance);
+
+  await t.throwsAsync(() => permit.config.axiosInstance.request({ method: 'GET', url: '/x' }));
+
+  // maxRetries: 2 -> initial call + two retries = three total.
+  t.is(rest.count(), 3);
+});
+
+test('a non-retryable status (400) is not retried', async (t) => {
+  const permit = await newPermit({ retry: tiny });
+  const rest = installRejectingAdapter(permit.config.axiosInstance, 400);
+
+  await t.throwsAsync(() => permit.config.axiosInstance.request({ method: 'GET', url: '/x' }));
+
+  t.is(rest.count(), 1);
+});
+
+test('a disallowed method on the REST instance is not retried', async (t) => {
+  const permit = await newPermit({ retry: tiny });
+  const rest = installRejectingAdapter(permit.config.axiosInstance);
+
+  // PUT is in DEFAULT_RETRY_METHODS but POST is not, so POST must not retry.
+  await t.throwsAsync(() => permit.config.axiosInstance.request({ method: 'POST', url: '/x' }));
+
+  t.is(rest.count(), 1);
+});
+
+test('disabled retry (retry: false) installs no retry', async (t) => {
+  const permit = await newPermit({ retry: false });
+  const rest = installRejectingAdapter(permit.config.axiosInstance);
+
+  await t.throwsAsync(() => permit.config.axiosInstance.request({ method: 'GET', url: '/x' }));
+
+  t.is(rest.count(), 1);
+});
+
+test.serial('maps axios-retry retryCount to our 0-based attempt number', async (t) => {
+  // axios-retry passes a 1-based retryCount; the interceptor must subtract one
+  // so the first retry uses attempt 0. With jitter removed, attempt 0 -> 30ms
+  // and attempt 1 (the off-by-one bug) -> 90ms. We capture the delay axios-retry
+  // schedules via setTimeout instead of measuring wall-clock time, so the check
+  // is deterministic and concurrency-safe.
+  const realRandom = Math.random;
+  const realSetTimeout = global.setTimeout;
+  const scheduledDelays: number[] = [];
+  Math.random = () => 0; // strip jitter
+  // Capture the delay, then fire immediately so the retry still proceeds.
+  global.setTimeout = ((fn: () => void, delay?: number): ReturnType<typeof setTimeout> => {
+    scheduledDelays.push(delay ?? 0);
+    return realSetTimeout(fn, 0);
+  }) as typeof setTimeout;
+  try {
+    const permit = await newPermit({
+      retry: { maxRetries: 1, retryDelay: 30, backoffMultiplier: 3, maxDelay: 10000 },
+    });
+    installRejectingAdapter(permit.config.axiosInstance);
+
+    await t.throwsAsync(() => permit.config.axiosInstance.request({ method: 'GET', url: '/x' }));
+
+    t.true(scheduledDelays.includes(30), `expected a 30ms delay, got ${scheduledDelays.join(',')}`);
+    t.false(scheduledDelays.includes(90), 'attempt-1 (off-by-one) delay must not be used');
+  } finally {
+    Math.random = realRandom;
+    global.setTimeout = realSetTimeout;
+  }
 });

--- a/src/tests/unit/retry-interceptor.spec.ts
+++ b/src/tests/unit/retry-interceptor.spec.ts
@@ -127,6 +127,17 @@ test('disabled retry (retry: false) installs no retry', async (t) => {
   t.is(rest.count(), 1);
 });
 
+test('REST instance never retries POST even when the user opts POST in', async (t) => {
+  // POST is stripped from the REST retryMethods regardless of user config, so
+  // non-idempotent REST writes are never repeated.
+  const permit = await newPermit({ retry: { ...tiny, retryMethods: ['GET', 'POST'] } });
+  const rest = installRejectingAdapter(permit.config.axiosInstance);
+
+  await t.throwsAsync(() => permit.config.axiosInstance.request({ method: 'POST', url: '/x' }));
+
+  t.is(rest.count(), 1);
+});
+
 test.serial('maps axios-retry retryCount to our 0-based attempt number', async (t) => {
   // axios-retry passes a 1-based retryCount; the interceptor must subtract one
   // so the first retry uses attempt 0. With jitter removed, attempt 0 -> 30ms

--- a/src/tests/unit/retry.spec.ts
+++ b/src/tests/unit/retry.spec.ts
@@ -6,7 +6,6 @@ import {
   DEFAULT_RETRY_CONFIG,
   defaultRetryCondition,
   IRetryConfig,
-  NON_RETRYABLE_STATUS_CODES,
   parseRetryAfter,
   resolveRetryConfig,
   RETRYABLE_STATUS_CODES,
@@ -38,10 +37,6 @@ function createAxiosError(status?: number): AxiosError {
 
 test('RETRYABLE_STATUS_CODES contains expected status codes', (t) => {
   t.deepEqual(RETRYABLE_STATUS_CODES, [408, 429, 500, 502, 503, 504]);
-});
-
-test('NON_RETRYABLE_STATUS_CODES contains expected status codes', (t) => {
-  t.deepEqual(NON_RETRYABLE_STATUS_CODES, [400, 401, 403, 404, 422]);
 });
 
 // ============================================
@@ -335,7 +330,6 @@ test('retry types are exported from SDK', async (t) => {
   const sdk = await import('../../index');
 
   t.truthy(sdk.RETRYABLE_STATUS_CODES);
-  t.truthy(sdk.NON_RETRYABLE_STATUS_CODES);
   t.deepEqual(sdk.RETRYABLE_STATUS_CODES, [408, 429, 500, 502, 503, 504]);
 });
 

--- a/src/tests/unit/retry.spec.ts
+++ b/src/tests/unit/retry.spec.ts
@@ -129,7 +129,7 @@ test('parseRetryAfter returns null for non digits-only delta-seconds', (t) => {
   t.is(parseRetryAfter('5abc'), null);
 });
 
-test('parseRetryAfter parses HTTP-date format', (t) => {
+test.serial('parseRetryAfter parses HTTP-date format', (t) => {
   const realNow = Date.now;
   try {
     const fixedNow = Date.UTC(2015, 9, 21, 7, 28, 0); // "Wed, 21 Oct 2015 07:28:00 GMT"
@@ -143,7 +143,7 @@ test('parseRetryAfter parses HTTP-date format', (t) => {
   }
 });
 
-test('parseRetryAfter returns 0 for past HTTP-date', (t) => {
+test.serial('parseRetryAfter returns 0 for past HTTP-date', (t) => {
   const realNow = Date.now;
   try {
     const fixedNow = Date.UTC(2015, 9, 21, 7, 28, 0);
@@ -249,6 +249,10 @@ test('resolveRetryConfig returns a copy that does not mutate the default', (t) =
   resolved.retryMethods.push('PATCH');
 
   t.deepEqual(DEFAULT_RETRY_CONFIG.retryMethods, ['GET', 'HEAD', 'OPTIONS', 'PUT', 'DELETE']);
+});
+
+test('DEFAULT_RETRY_CONFIG.retryMethods is frozen', (t) => {
+  t.true(Object.isFrozen(DEFAULT_RETRY_CONFIG.retryMethods));
 });
 
 test('resolveRetryConfig returns disabled config when false', (t) => {

--- a/src/tests/unit/retry.spec.ts
+++ b/src/tests/unit/retry.spec.ts
@@ -1,0 +1,339 @@
+import test from 'ava';
+import { AxiosError, AxiosHeaders } from 'axios';
+
+import {
+  DEFAULT_RETRY_CONFIG,
+  defaultRetryCondition,
+  calculateRetryDelay,
+  parseRetryAfter,
+  resolveRetryConfig,
+  RETRYABLE_STATUS_CODES,
+  NON_RETRYABLE_STATUS_CODES,
+  IRetryConfig,
+} from '../../utils/retry';
+
+// Helper to create mock AxiosError
+function createAxiosError(status?: number): AxiosError {
+  const error = new Error('Request failed') as AxiosError;
+  error.isAxiosError = true;
+  error.config = { headers: new AxiosHeaders() };
+  error.toJSON = () => ({});
+
+  if (status !== undefined) {
+    error.response = {
+      status,
+      statusText: 'Error',
+      headers: {},
+      config: { headers: new AxiosHeaders() },
+      data: {},
+    };
+  }
+
+  return error;
+}
+
+// ============================================
+// Tests for RETRYABLE_STATUS_CODES
+// ============================================
+
+test('RETRYABLE_STATUS_CODES contains expected status codes', (t) => {
+  t.deepEqual(RETRYABLE_STATUS_CODES, [408, 429, 500, 502, 503, 504]);
+});
+
+test('NON_RETRYABLE_STATUS_CODES contains expected status codes', (t) => {
+  t.deepEqual(NON_RETRYABLE_STATUS_CODES, [400, 401, 403, 404, 422]);
+});
+
+// ============================================
+// Tests for defaultRetryCondition
+// ============================================
+
+test('defaultRetryCondition returns true for network errors (no response)', (t) => {
+  const error = createAxiosError();
+  t.true(defaultRetryCondition(error));
+});
+
+test('defaultRetryCondition returns true for 408 Request Timeout', (t) => {
+  const error = createAxiosError(408);
+  t.true(defaultRetryCondition(error));
+});
+
+test('defaultRetryCondition returns true for 429 Too Many Requests', (t) => {
+  const error = createAxiosError(429);
+  t.true(defaultRetryCondition(error));
+});
+
+test('defaultRetryCondition returns true for 500 Internal Server Error', (t) => {
+  const error = createAxiosError(500);
+  t.true(defaultRetryCondition(error));
+});
+
+test('defaultRetryCondition returns true for 502 Bad Gateway', (t) => {
+  const error = createAxiosError(502);
+  t.true(defaultRetryCondition(error));
+});
+
+test('defaultRetryCondition returns true for 503 Service Unavailable', (t) => {
+  const error = createAxiosError(503);
+  t.true(defaultRetryCondition(error));
+});
+
+test('defaultRetryCondition returns true for 504 Gateway Timeout', (t) => {
+  const error = createAxiosError(504);
+  t.true(defaultRetryCondition(error));
+});
+
+test('defaultRetryCondition returns false for 400 Bad Request', (t) => {
+  const error = createAxiosError(400);
+  t.false(defaultRetryCondition(error));
+});
+
+test('defaultRetryCondition returns false for 401 Unauthorized', (t) => {
+  const error = createAxiosError(401);
+  t.false(defaultRetryCondition(error));
+});
+
+test('defaultRetryCondition returns false for 403 Forbidden', (t) => {
+  const error = createAxiosError(403);
+  t.false(defaultRetryCondition(error));
+});
+
+test('defaultRetryCondition returns false for 404 Not Found', (t) => {
+  const error = createAxiosError(404);
+  t.false(defaultRetryCondition(error));
+});
+
+test('defaultRetryCondition returns false for 422 Unprocessable Entity', (t) => {
+  const error = createAxiosError(422);
+  t.false(defaultRetryCondition(error));
+});
+
+test('defaultRetryCondition returns false for 200 OK', (t) => {
+  const error = createAxiosError(200);
+  t.false(defaultRetryCondition(error));
+});
+
+// ============================================
+// Tests for parseRetryAfter
+// ============================================
+
+test('parseRetryAfter parses integer seconds correctly', (t) => {
+  t.is(parseRetryAfter('5'), 5000);
+  t.is(parseRetryAfter('60'), 60000);
+  t.is(parseRetryAfter('0'), 0);
+  t.is(parseRetryAfter('120'), 120000);
+});
+
+test('parseRetryAfter returns null for invalid values', (t) => {
+  t.is(parseRetryAfter('invalid'), null);
+  t.is(parseRetryAfter(''), null);
+  t.is(parseRetryAfter('abc123'), null);
+});
+
+test('parseRetryAfter parses HTTP-date format', (t) => {
+  // Use a future date
+  const futureDate = new Date(Date.now() + 10000);
+  const httpDate = futureDate.toUTCString();
+  const result = parseRetryAfter(httpDate);
+
+  t.truthy(result);
+  // Should be approximately 10 seconds (10000ms), with some tolerance
+  t.true(result! > 9000 && result! < 11000);
+});
+
+test('parseRetryAfter returns 0 for past HTTP-date', (t) => {
+  const pastDate = new Date(Date.now() - 10000);
+  const httpDate = pastDate.toUTCString();
+  const result = parseRetryAfter(httpDate);
+
+  t.is(result, 0);
+});
+
+// ============================================
+// Tests for calculateRetryDelay
+// ============================================
+
+test('calculateRetryDelay calculates exponential backoff correctly', (t) => {
+  const config = { ...DEFAULT_RETRY_CONFIG, retryDelay: 1000, backoffMultiplier: 2 };
+
+  // First retry (attempt 0): 1000 * 2^0 = 1000ms + jitter
+  const delay0 = calculateRetryDelay(0, config);
+  t.true(delay0 >= 1000 && delay0 <= 1100); // 10% jitter max
+
+  // Second retry (attempt 1): 1000 * 2^1 = 2000ms + jitter
+  const delay1 = calculateRetryDelay(1, config);
+  t.true(delay1 >= 2000 && delay1 <= 2200);
+
+  // Third retry (attempt 2): 1000 * 2^2 = 4000ms + jitter
+  const delay2 = calculateRetryDelay(2, config);
+  t.true(delay2 >= 4000 && delay2 <= 4400);
+});
+
+test('calculateRetryDelay respects maxDelay limit', (t) => {
+  const config = {
+    ...DEFAULT_RETRY_CONFIG,
+    retryDelay: 1000,
+    backoffMultiplier: 10,
+    maxDelay: 5000,
+  };
+
+  // Even with high multiplier, should cap at maxDelay
+  const delay = calculateRetryDelay(5, config);
+  t.true(delay <= 5000);
+});
+
+test('calculateRetryDelay respects Retry-After header', (t) => {
+  const config = { ...DEFAULT_RETRY_CONFIG, respectRetryAfter: true };
+
+  const delay = calculateRetryDelay(0, config, '3');
+  t.is(delay, 3000);
+});
+
+test('calculateRetryDelay caps Retry-After at maxDelay', (t) => {
+  const config = { ...DEFAULT_RETRY_CONFIG, respectRetryAfter: true, maxDelay: 5000 };
+
+  const delay = calculateRetryDelay(0, config, '60');
+  t.is(delay, 5000);
+});
+
+test('calculateRetryDelay ignores Retry-After when disabled', (t) => {
+  const config = {
+    ...DEFAULT_RETRY_CONFIG,
+    respectRetryAfter: false,
+    retryDelay: 1000,
+    backoffMultiplier: 2,
+  };
+
+  const delay = calculateRetryDelay(0, config, '60');
+  // Should use exponential backoff, not Retry-After
+  t.true(delay >= 1000 && delay <= 1100);
+});
+
+// ============================================
+// Tests for resolveRetryConfig
+// ============================================
+
+test('resolveRetryConfig returns defaults when config is undefined', (t) => {
+  const resolved = resolveRetryConfig(undefined);
+
+  t.true(resolved.enabled);
+  t.is(resolved.maxRetries, 3);
+  t.is(resolved.retryDelay, 1000);
+  t.is(resolved.backoffMultiplier, 2);
+  t.is(resolved.maxDelay, 30000);
+  t.true(resolved.respectRetryAfter);
+  t.deepEqual(resolved.retryMethods, ['GET', 'HEAD', 'OPTIONS', 'PUT', 'DELETE']);
+});
+
+test('resolveRetryConfig returns disabled config when false', (t) => {
+  const resolved = resolveRetryConfig(false);
+
+  t.false(resolved.enabled);
+  // Other defaults should still be present
+  t.is(resolved.maxRetries, 3);
+});
+
+test('resolveRetryConfig merges user config with defaults', (t) => {
+  const userConfig: IRetryConfig = {
+    maxRetries: 5,
+    retryDelay: 500,
+  };
+
+  const resolved = resolveRetryConfig(userConfig);
+
+  t.true(resolved.enabled);
+  t.is(resolved.maxRetries, 5); // User value
+  t.is(resolved.retryDelay, 500); // User value
+  t.is(resolved.backoffMultiplier, 2); // Default
+  t.is(resolved.maxDelay, 30000); // Default
+});
+
+test('resolveRetryConfig allows custom retry condition', (t) => {
+  const customCondition = () => false;
+  const userConfig: IRetryConfig = {
+    retryCondition: customCondition,
+  };
+
+  const resolved = resolveRetryConfig(userConfig);
+
+  t.is(resolved.retryCondition, customCondition);
+});
+
+test('resolveRetryConfig allows custom retry methods', (t) => {
+  const userConfig: IRetryConfig = {
+    retryMethods: ['GET', 'POST'],
+  };
+
+  const resolved = resolveRetryConfig(userConfig);
+
+  t.deepEqual(resolved.retryMethods, ['GET', 'POST']);
+});
+
+test('resolveRetryConfig allows disabling via enabled: false', (t) => {
+  const userConfig: IRetryConfig = {
+    enabled: false,
+    maxRetries: 10,
+  };
+
+  const resolved = resolveRetryConfig(userConfig);
+
+  t.false(resolved.enabled);
+  t.is(resolved.maxRetries, 10);
+});
+
+// ============================================
+// Tests for DEFAULT_RETRY_CONFIG
+// ============================================
+
+test('DEFAULT_RETRY_CONFIG has expected default values', (t) => {
+  t.true(DEFAULT_RETRY_CONFIG.enabled);
+  t.is(DEFAULT_RETRY_CONFIG.maxRetries, 3);
+  t.is(DEFAULT_RETRY_CONFIG.retryDelay, 1000);
+  t.is(DEFAULT_RETRY_CONFIG.backoffMultiplier, 2);
+  t.is(DEFAULT_RETRY_CONFIG.maxDelay, 30000);
+  t.true(DEFAULT_RETRY_CONFIG.respectRetryAfter);
+  t.deepEqual(DEFAULT_RETRY_CONFIG.retryMethods, ['GET', 'HEAD', 'OPTIONS', 'PUT', 'DELETE']);
+  t.is(typeof DEFAULT_RETRY_CONFIG.retryCondition, 'function');
+});
+
+// ============================================
+// Tests for exports from SDK
+// ============================================
+
+test('retry types are exported from SDK', async (t) => {
+  const sdk = await import('../../index');
+
+  t.truthy(sdk.RETRYABLE_STATUS_CODES);
+  t.truthy(sdk.NON_RETRYABLE_STATUS_CODES);
+  t.deepEqual(sdk.RETRYABLE_STATUS_CODES, [408, 429, 500, 502, 503, 504]);
+});
+
+test('Permit accepts retry configuration', async (t) => {
+  const { Permit } = await import('../../index');
+
+  // With retry enabled (default)
+  const permit1 = new Permit({ token: 'test' });
+  t.truthy(permit1);
+
+  // With custom retry config
+  const permit2 = new Permit({
+    token: 'test',
+    retry: { maxRetries: 5 },
+  });
+  t.truthy(permit2);
+
+  // With retry disabled
+  const permit3 = new Permit({
+    token: 'test',
+    retry: false,
+  });
+  t.truthy(permit3);
+
+  // With separate PDP retry config
+  const permit4 = new Permit({
+    token: 'test',
+    retry: { maxRetries: 3 },
+    pdpRetry: { maxRetries: 5 },
+  });
+  t.truthy(permit4);
+});

--- a/src/tests/unit/retry.spec.ts
+++ b/src/tests/unit/retry.spec.ts
@@ -255,6 +255,10 @@ test('DEFAULT_RETRY_CONFIG.retryMethods is frozen', (t) => {
   t.true(Object.isFrozen(DEFAULT_RETRY_CONFIG.retryMethods));
 });
 
+test('RETRYABLE_STATUS_CODES is frozen', (t) => {
+  t.true(Object.isFrozen(RETRYABLE_STATUS_CODES));
+});
+
 test('resolveRetryConfig returns disabled config when false', (t) => {
   const resolved = resolveRetryConfig(false);
 

--- a/src/tests/unit/retry.spec.ts
+++ b/src/tests/unit/retry.spec.ts
@@ -2,14 +2,14 @@ import test from 'ava';
 import { AxiosError, AxiosHeaders } from 'axios';
 
 import {
+  calculateRetryDelay,
   DEFAULT_RETRY_CONFIG,
   defaultRetryCondition,
-  calculateRetryDelay,
+  IRetryConfig,
+  NON_RETRYABLE_STATUS_CODES,
   parseRetryAfter,
   resolveRetryConfig,
   RETRYABLE_STATUS_CODES,
-  NON_RETRYABLE_STATUS_CODES,
-  IRetryConfig,
 } from '../../utils/retry';
 
 // Helper to create mock AxiosError

--- a/src/tests/unit/retry.spec.ts
+++ b/src/tests/unit/retry.spec.ts
@@ -130,23 +130,35 @@ test('parseRetryAfter returns null for invalid values', (t) => {
   t.is(parseRetryAfter('abc123'), null);
 });
 
-test('parseRetryAfter parses HTTP-date format', (t) => {
-  // Use a future date
-  const futureDate = new Date(Date.now() + 10000);
-  const httpDate = futureDate.toUTCString();
-  const result = parseRetryAfter(httpDate);
+test('parseRetryAfter returns null for non digits-only delta-seconds', (t) => {
+  t.is(parseRetryAfter('5abc'), null);
+});
 
-  t.truthy(result);
-  // Should be approximately 10 seconds (10000ms), with some tolerance
-  t.true(result! > 9000 && result! < 11000);
+test('parseRetryAfter parses HTTP-date format', (t) => {
+  const realNow = Date.now;
+  try {
+    const fixedNow = Date.UTC(2015, 9, 21, 7, 28, 0); // "Wed, 21 Oct 2015 07:28:00 GMT"
+    Date.now = () => fixedNow;
+
+    // 10 seconds in the future relative to the stubbed clock
+    const httpDate = new Date(fixedNow + 10000).toUTCString();
+    t.is(parseRetryAfter(httpDate), 10000);
+  } finally {
+    Date.now = realNow;
+  }
 });
 
 test('parseRetryAfter returns 0 for past HTTP-date', (t) => {
-  const pastDate = new Date(Date.now() - 10000);
-  const httpDate = pastDate.toUTCString();
-  const result = parseRetryAfter(httpDate);
+  const realNow = Date.now;
+  try {
+    const fixedNow = Date.UTC(2015, 9, 21, 7, 28, 0);
+    Date.now = () => fixedNow;
 
-  t.is(result, 0);
+    const httpDate = new Date(fixedNow - 10000).toUTCString();
+    t.is(parseRetryAfter(httpDate), 0);
+  } finally {
+    Date.now = realNow;
+  }
 });
 
 // ============================================
@@ -216,13 +228,32 @@ test('calculateRetryDelay ignores Retry-After when disabled', (t) => {
 test('resolveRetryConfig returns defaults when config is undefined', (t) => {
   const resolved = resolveRetryConfig(undefined);
 
-  t.true(resolved.enabled);
+  t.false(resolved.enabled);
   t.is(resolved.maxRetries, 3);
   t.is(resolved.retryDelay, 1000);
   t.is(resolved.backoffMultiplier, 2);
   t.is(resolved.maxDelay, 30000);
   t.true(resolved.respectRetryAfter);
   t.deepEqual(resolved.retryMethods, ['GET', 'HEAD', 'OPTIONS', 'PUT', 'DELETE']);
+});
+
+test('resolveRetryConfig opts in when a config object is provided', (t) => {
+  const resolved = resolveRetryConfig({ maxRetries: 5 });
+
+  t.true(resolved.enabled);
+});
+
+test('resolveRetryConfig normalizes retry methods to uppercase', (t) => {
+  const resolved = resolveRetryConfig({ retryMethods: ['get', 'post'] });
+
+  t.deepEqual(resolved.retryMethods, ['GET', 'POST']);
+});
+
+test('resolveRetryConfig returns a copy that does not mutate the default', (t) => {
+  const resolved = resolveRetryConfig(undefined);
+  resolved.retryMethods.push('PATCH');
+
+  t.deepEqual(DEFAULT_RETRY_CONFIG.retryMethods, ['GET', 'HEAD', 'OPTIONS', 'PUT', 'DELETE']);
 });
 
 test('resolveRetryConfig returns disabled config when false', (t) => {
@@ -286,7 +317,7 @@ test('resolveRetryConfig allows disabling via enabled: false', (t) => {
 // ============================================
 
 test('DEFAULT_RETRY_CONFIG has expected default values', (t) => {
-  t.true(DEFAULT_RETRY_CONFIG.enabled);
+  t.false(DEFAULT_RETRY_CONFIG.enabled);
   t.is(DEFAULT_RETRY_CONFIG.maxRetries, 3);
   t.is(DEFAULT_RETRY_CONFIG.retryDelay, 1000);
   t.is(DEFAULT_RETRY_CONFIG.backoffMultiplier, 2);
@@ -311,7 +342,7 @@ test('retry types are exported from SDK', async (t) => {
 test('Permit accepts retry configuration', async (t) => {
   const { Permit } = await import('../../index');
 
-  // With retry enabled (default)
+  // With retry off (opt-in default)
   const permit1 = new Permit({ token: 'test' });
   t.truthy(permit1);
 

--- a/src/utils/retry-interceptor.ts
+++ b/src/utils/retry-interceptor.ts
@@ -54,7 +54,7 @@ export class AxiosRetryInterceptor {
         const url = error.config?.url ?? 'unknown';
         logger.warn(
           `[${clientName}] Request failed (${status}), ` +
-            `retrying (attempt ${retryCount}/${config.maxRetries}): ${method} ${url}`,
+            `retry ${retryCount}/${config.maxRetries}: ${method} ${url}`,
         );
       },
     });

--- a/src/utils/retry-interceptor.ts
+++ b/src/utils/retry-interceptor.ts
@@ -3,8 +3,12 @@ import { Logger } from 'pino';
 
 import { calculateRetryDelay, IResolvedRetryConfig } from './retry';
 
-// Symbol to track retry state on request config (avoids polluting the config object)
-const RETRY_COUNT_KEY = Symbol('permitRetryCount');
+// String key used to track the retry count on the request config. A string
+// (rather than a Symbol) is required: axios's mergeConfig — run on every
+// axiosInstance.request() during a retry — only carries string-keyed
+// properties, so a Symbol key would be dropped and the counter would reset to
+// 0 each retry, causing an infinite retry loop.
+const RETRY_COUNT_KEY = '__permitRetryCount';
 
 /**
  * Extended request config with retry tracking

--- a/src/utils/retry-interceptor.ts
+++ b/src/utils/retry-interceptor.ts
@@ -1,0 +1,91 @@
+import { AxiosError, AxiosInstance, InternalAxiosRequestConfig } from 'axios';
+import { Logger } from 'pino';
+
+import { calculateRetryDelay, IResolvedRetryConfig } from './retry';
+
+// Symbols to track retry state on request config (avoids polluting the config object)
+const RETRY_COUNT_KEY = '__permitRetryCount';
+
+/**
+ * Extended request config with retry tracking
+ */
+interface RetryableRequestConfig extends InternalAxiosRequestConfig {
+  [RETRY_COUNT_KEY]?: number;
+}
+
+/**
+ * Axios interceptor that implements retry logic with exponential backoff
+ */
+export class AxiosRetryInterceptor {
+  /**
+   * Setup retry interceptor on an axios instance
+   *
+   * @param axiosInstance - The axios instance to add retry capability to
+   * @param config - Resolved retry configuration
+   * @param logger - Logger instance for retry attempt logging
+   * @param clientName - Name of the client for logging purposes (e.g., 'API', 'PDP', 'OPA')
+   */
+  static setupInterceptor(
+    axiosInstance: AxiosInstance,
+    config: IResolvedRetryConfig,
+    logger: Logger,
+    clientName = 'HTTP',
+  ): void {
+    if (!config.enabled) {
+      return;
+    }
+
+    axiosInstance.interceptors.response.use(
+      // Success handler - pass through unchanged
+      (response) => response,
+
+      // Error handler - implement retry logic
+      async (error: AxiosError) => {
+        const originalRequest = error.config as RetryableRequestConfig | undefined;
+
+        // If no request config, cannot retry
+        if (!originalRequest) {
+          return Promise.reject(error);
+        }
+
+        // Initialize or get current retry count
+        const currentRetryCount = originalRequest[RETRY_COUNT_KEY] ?? 0;
+
+        // Check if we should retry this request
+        const method = (originalRequest.method ?? 'GET').toUpperCase();
+        const shouldRetryMethod = config.retryMethods.includes(method);
+        const shouldRetryError = config.retryCondition(error);
+        const hasRetriesLeft = currentRetryCount < config.maxRetries;
+
+        // If any condition fails, reject with original error
+        if (!shouldRetryMethod || !shouldRetryError || !hasRetriesLeft) {
+          return Promise.reject(error);
+        }
+
+        // Increment retry count for next attempt
+        originalRequest[RETRY_COUNT_KEY] = currentRetryCount + 1;
+
+        // Calculate delay before retry
+        const retryAfterHeader = error.response?.headers?.['retry-after'] as string | undefined;
+        const delay = calculateRetryDelay(currentRetryCount, config, retryAfterHeader);
+
+        // Log retry attempt
+        const statusInfo = error.response?.status ?? 'network error';
+        const url = originalRequest.url ?? 'unknown';
+        logger.warn(
+          `[${clientName}] Request failed (${statusInfo}), ` +
+            `retrying in ${Math.round(delay)}ms (attempt ${currentRetryCount + 1}/${
+              config.maxRetries
+            }): ` +
+            `${method} ${url}`,
+        );
+
+        // Wait for the calculated delay
+        await new Promise((resolve) => setTimeout(resolve, delay));
+
+        // Retry the request
+        return axiosInstance.request(originalRequest);
+      },
+    );
+  }
+}

--- a/src/utils/retry-interceptor.ts
+++ b/src/utils/retry-interceptor.ts
@@ -3,8 +3,8 @@ import { Logger } from 'pino';
 
 import { calculateRetryDelay, IResolvedRetryConfig } from './retry';
 
-// Symbols to track retry state on request config (avoids polluting the config object)
-const RETRY_COUNT_KEY = '__permitRetryCount';
+// Symbol to track retry state on request config (avoids polluting the config object)
+const RETRY_COUNT_KEY = Symbol('permitRetryCount');
 
 /**
  * Extended request config with retry tracking

--- a/src/utils/retry-interceptor.ts
+++ b/src/utils/retry-interceptor.ts
@@ -1,28 +1,16 @@
-import { AxiosError, AxiosInstance, InternalAxiosRequestConfig } from 'axios';
+import { AxiosError, AxiosInstance } from 'axios';
+import axiosRetry from 'axios-retry';
 import { Logger } from 'pino';
 
 import { calculateRetryDelay, IResolvedRetryConfig } from './retry';
 
-// String key used to track the retry count on the request config. A string
-// (rather than a Symbol) is required: axios's mergeConfig — run on every
-// axiosInstance.request() during a retry — only carries string-keyed
-// properties, so a Symbol key would be dropped and the counter would reset to
-// 0 each retry, causing an infinite retry loop.
-const RETRY_COUNT_KEY = '__permitRetryCount';
-
 /**
- * Extended request config with retry tracking
- */
-interface RetryableRequestConfig extends InternalAxiosRequestConfig {
-  [RETRY_COUNT_KEY]?: number;
-}
-
-/**
- * Axios interceptor that implements retry logic with exponential backoff
+ * Installs retry behavior on an axios instance using the axios-retry library,
+ * driven by our resolved retry configuration (delay/condition policy).
  */
 export class AxiosRetryInterceptor {
   /**
-   * Setup retry interceptor on an axios instance
+   * Setup retry on an axios instance.
    *
    * @param axiosInstance - The axios instance to add retry capability to
    * @param config - Resolved retry configuration
@@ -39,57 +27,36 @@ export class AxiosRetryInterceptor {
       return;
     }
 
-    axiosInstance.interceptors.response.use(
-      // Success handler - pass through unchanged
-      (response) => response,
+    axiosRetry(axiosInstance, {
+      retries: config.maxRetries,
+      shouldResetTimeout: true,
 
-      // Error handler - implement retry logic
-      async (error: AxiosError) => {
-        const originalRequest = error.config as RetryableRequestConfig | undefined;
-
-        // If no request config, cannot retry
-        if (!originalRequest) {
-          return Promise.reject(error);
+      // Preserve our policy: per-instance method filtering (REST excludes POST,
+      // PDP includes it) plus our error condition (network + retryable status).
+      retryCondition: (error: AxiosError): boolean => {
+        const method = (error.config?.method ?? 'GET').toUpperCase();
+        if (!config.retryMethods.includes(method)) {
+          return false;
         }
-
-        // Initialize or get current retry count
-        const currentRetryCount = originalRequest[RETRY_COUNT_KEY] ?? 0;
-
-        // Check if we should retry this request
-        const method = (originalRequest.method ?? 'GET').toUpperCase();
-        const shouldRetryMethod = config.retryMethods.includes(method);
-        const shouldRetryError = config.retryCondition(error);
-        const hasRetriesLeft = currentRetryCount < config.maxRetries;
-
-        // If any condition fails, reject with original error
-        if (!shouldRetryMethod || !shouldRetryError || !hasRetriesLeft) {
-          return Promise.reject(error);
-        }
-
-        // Increment retry count for next attempt
-        originalRequest[RETRY_COUNT_KEY] = currentRetryCount + 1;
-
-        // Calculate delay before retry
-        const retryAfterHeader = error.response?.headers?.['retry-after'] as string | undefined;
-        const delay = calculateRetryDelay(currentRetryCount, config, retryAfterHeader);
-
-        // Log retry attempt
-        const statusInfo = error.response?.status ?? 'network error';
-        const url = originalRequest.url ?? 'unknown';
-        logger.warn(
-          `[${clientName}] Request failed (${statusInfo}), ` +
-            `retrying in ${Math.round(delay)}ms (attempt ${currentRetryCount + 1}/${
-              config.maxRetries
-            }): ` +
-            `${method} ${url}`,
-        );
-
-        // Wait for the calculated delay
-        await new Promise((resolve) => setTimeout(resolve, delay));
-
-        // Retry the request
-        return axiosInstance.request(originalRequest);
+        return config.retryCondition(error);
       },
-    );
+
+      // axios-retry's retryCount is 1-based (1 on the first retry); our
+      // calculateRetryDelay expects a 0-based attempt number, so subtract one.
+      retryDelay: (retryCount: number, error: AxiosError): number => {
+        const retryAfterHeader = error.response?.headers?.['retry-after'] as string | undefined;
+        return calculateRetryDelay(retryCount - 1, config, retryAfterHeader);
+      },
+
+      onRetry: (retryCount: number, error: AxiosError): void => {
+        const status = error.response?.status ?? 'network error';
+        const method = (error.config?.method ?? 'GET').toUpperCase();
+        const url = error.config?.url ?? 'unknown';
+        logger.warn(
+          `[${clientName}] Request failed (${status}), ` +
+            `retrying (attempt ${retryCount}/${config.maxRetries}): ${method} ${url}`,
+        );
+      },
+    });
   }
 }

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -6,14 +6,9 @@ import { AxiosError } from 'axios';
 export const RETRYABLE_STATUS_CODES = [408, 429, 500, 502, 503, 504];
 
 /**
- * HTTP status codes that should NOT trigger a retry
- */
-export const NON_RETRYABLE_STATUS_CODES = [400, 401, 403, 404, 422];
-
-/**
  * Default HTTP methods that are safe to retry
  */
-export const DEFAULT_RETRY_METHODS = ['GET', 'HEAD', 'OPTIONS', 'PUT', 'DELETE'];
+const DEFAULT_RETRY_METHODS = ['GET', 'HEAD', 'OPTIONS', 'PUT', 'DELETE'];
 
 /**
  * Function type for custom retry condition evaluation

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -1,0 +1,200 @@
+import { AxiosError } from 'axios';
+
+/**
+ * HTTP status codes that should trigger a retry
+ */
+export const RETRYABLE_STATUS_CODES = [408, 429, 500, 502, 503, 504];
+
+/**
+ * HTTP status codes that should NOT trigger a retry
+ */
+export const NON_RETRYABLE_STATUS_CODES = [400, 401, 403, 404, 422];
+
+/**
+ * Default HTTP methods that are safe to retry
+ */
+export const DEFAULT_RETRY_METHODS = ['GET', 'HEAD', 'OPTIONS', 'PUT', 'DELETE'];
+
+/**
+ * Function type for custom retry condition evaluation
+ */
+export type RetryConditionFn = (error: AxiosError) => boolean;
+
+/**
+ * Configuration options for the retry mechanism
+ */
+export interface IRetryConfig {
+  /**
+   * Whether retry is enabled. Defaults to true.
+   */
+  enabled?: boolean;
+
+  /**
+   * Maximum number of retry attempts. Defaults to 3.
+   */
+  maxRetries?: number;
+
+  /**
+   * Initial delay between retries in milliseconds. Defaults to 1000 (1 second).
+   */
+  retryDelay?: number;
+
+  /**
+   * Multiplier for exponential backoff. Defaults to 2.
+   * Each retry will wait: retryDelay * (backoffMultiplier ^ attemptNumber)
+   */
+  backoffMultiplier?: number;
+
+  /**
+   * Maximum delay between retries in milliseconds. Defaults to 30000 (30 seconds).
+   * Prevents exponential backoff from growing too large.
+   */
+  maxDelay?: number;
+
+  /**
+   * Custom function to determine if a request should be retried.
+   * If not provided, uses default retry condition (network errors + retryable status codes).
+   */
+  retryCondition?: RetryConditionFn;
+
+  /**
+   * Whether to respect the Retry-After header for 429 responses. Defaults to true.
+   */
+  respectRetryAfter?: boolean;
+
+  /**
+   * HTTP methods to retry. Defaults to ['GET', 'HEAD', 'OPTIONS', 'PUT', 'DELETE'].
+   * POST is excluded by default as it may not be idempotent.
+   */
+  retryMethods?: string[];
+}
+
+/**
+ * Resolved retry configuration with all defaults applied
+ */
+export interface IResolvedRetryConfig {
+  enabled: boolean;
+  maxRetries: number;
+  retryDelay: number;
+  backoffMultiplier: number;
+  maxDelay: number;
+  retryCondition: RetryConditionFn;
+  respectRetryAfter: boolean;
+  retryMethods: string[];
+}
+
+/**
+ * Default retry condition: retry on network errors and retryable HTTP status codes
+ */
+export function defaultRetryCondition(error: AxiosError): boolean {
+  // Network errors (no response) - connection refused, timeout, etc.
+  if (!error.response) {
+    return true;
+  }
+
+  // Retryable status codes
+  return RETRYABLE_STATUS_CODES.includes(error.response.status);
+}
+
+/**
+ * Default retry configuration values
+ */
+export const DEFAULT_RETRY_CONFIG: IResolvedRetryConfig = {
+  enabled: true,
+  maxRetries: 3,
+  retryDelay: 1000,
+  backoffMultiplier: 2,
+  maxDelay: 30000,
+  retryCondition: defaultRetryCondition,
+  respectRetryAfter: true,
+  retryMethods: DEFAULT_RETRY_METHODS,
+};
+
+/**
+ * Parse Retry-After header value
+ * Supports both seconds (integer) and HTTP-date formats
+ *
+ * @param value - The Retry-After header value
+ * @returns The delay in milliseconds, or null if parsing fails
+ */
+export function parseRetryAfter(value: string): number | null {
+  // Try parsing as seconds (integer)
+  const seconds = parseInt(value, 10);
+  if (!isNaN(seconds)) {
+    return seconds * 1000;
+  }
+
+  // Try parsing as HTTP-date (e.g., "Wed, 21 Oct 2015 07:28:00 GMT")
+  const date = Date.parse(value);
+  if (!isNaN(date)) {
+    return Math.max(0, date - Date.now());
+  }
+
+  return null;
+}
+
+/**
+ * Calculate delay for next retry attempt using exponential backoff with jitter
+ *
+ * @param attemptNumber - The current retry attempt number (0-indexed)
+ * @param config - The resolved retry configuration
+ * @param retryAfterHeader - Optional Retry-After header value from response
+ * @returns The delay in milliseconds before the next retry
+ */
+export function calculateRetryDelay(
+  attemptNumber: number,
+  config: IResolvedRetryConfig,
+  retryAfterHeader?: string,
+): number {
+  // Respect Retry-After header if present and configured
+  if (config.respectRetryAfter && retryAfterHeader) {
+    const retryAfterMs = parseRetryAfter(retryAfterHeader);
+    if (retryAfterMs !== null) {
+      return Math.min(retryAfterMs, config.maxDelay);
+    }
+  }
+
+  // Exponential backoff: delay * (multiplier ^ attempt)
+  const exponentialDelay = config.retryDelay * Math.pow(config.backoffMultiplier, attemptNumber);
+
+  // Add jitter (0-10% of the delay) to prevent thundering herd
+  const jitter = Math.random() * 0.1 * exponentialDelay;
+
+  // Apply max delay cap
+  return Math.min(exponentialDelay + jitter, config.maxDelay);
+}
+
+/**
+ * Resolve user-provided retry config with defaults
+ *
+ * @param userConfig - User-provided retry configuration or false to disable
+ * @returns Resolved configuration with all defaults applied
+ */
+export function resolveRetryConfig(
+  userConfig: IRetryConfig | false | undefined,
+): IResolvedRetryConfig {
+  // If explicitly disabled, return disabled config
+  if (userConfig === false) {
+    return {
+      ...DEFAULT_RETRY_CONFIG,
+      enabled: false,
+    };
+  }
+
+  // If undefined or empty, use defaults
+  if (!userConfig) {
+    return DEFAULT_RETRY_CONFIG;
+  }
+
+  // Merge user config with defaults
+  return {
+    enabled: userConfig.enabled ?? DEFAULT_RETRY_CONFIG.enabled,
+    maxRetries: userConfig.maxRetries ?? DEFAULT_RETRY_CONFIG.maxRetries,
+    retryDelay: userConfig.retryDelay ?? DEFAULT_RETRY_CONFIG.retryDelay,
+    backoffMultiplier: userConfig.backoffMultiplier ?? DEFAULT_RETRY_CONFIG.backoffMultiplier,
+    maxDelay: userConfig.maxDelay ?? DEFAULT_RETRY_CONFIG.maxDelay,
+    retryCondition: userConfig.retryCondition ?? DEFAULT_RETRY_CONFIG.retryCondition,
+    respectRetryAfter: userConfig.respectRetryAfter ?? DEFAULT_RETRY_CONFIG.respectRetryAfter,
+    retryMethods: userConfig.retryMethods ?? DEFAULT_RETRY_CONFIG.retryMethods,
+  };
+}

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -1,9 +1,12 @@
 import { AxiosError } from 'axios';
 
 /**
- * HTTP status codes that should trigger a retry
+ * HTTP status codes that should trigger a retry.
+ * Frozen so consumers cannot mutate the SDK-wide retry behavior.
  */
-export const RETRYABLE_STATUS_CODES = [408, 429, 500, 502, 503, 504];
+export const RETRYABLE_STATUS_CODES: readonly number[] = Object.freeze([
+  408, 429, 500, 502, 503, 504,
+]);
 
 /**
  * Default HTTP methods that are safe to retry.

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -25,7 +25,9 @@ export type RetryConditionFn = (error: AxiosError) => boolean;
  */
 export interface IRetryConfig {
   /**
-   * Whether retry is enabled. Defaults to true.
+   * Whether retry is enabled. Retries are opt-in: they are off unless a retry
+   * config object is supplied (which opts you in) or `enabled: true` is set
+   * explicitly. The default config is disabled.
    */
   enabled?: boolean;
 
@@ -97,10 +99,11 @@ export function defaultRetryCondition(error: AxiosError): boolean {
 }
 
 /**
- * Default retry configuration values
+ * Default retry configuration values.
+ * Retries are opt-in, so the default config is disabled.
  */
-export const DEFAULT_RETRY_CONFIG: IResolvedRetryConfig = {
-  enabled: true,
+export const DEFAULT_RETRY_CONFIG: IResolvedRetryConfig = Object.freeze({
+  enabled: false,
   maxRetries: 3,
   retryDelay: 1000,
   backoffMultiplier: 2,
@@ -108,7 +111,7 @@ export const DEFAULT_RETRY_CONFIG: IResolvedRetryConfig = {
   retryCondition: defaultRetryCondition,
   respectRetryAfter: true,
   retryMethods: DEFAULT_RETRY_METHODS,
-};
+});
 
 /**
  * Parse Retry-After header value
@@ -118,10 +121,11 @@ export const DEFAULT_RETRY_CONFIG: IResolvedRetryConfig = {
  * @returns The delay in milliseconds, or null if parsing fails
  */
 export function parseRetryAfter(value: string): number | null {
-  // Try parsing as seconds (integer)
-  const seconds = parseInt(value, 10);
-  if (!isNaN(seconds)) {
-    return seconds * 1000;
+  // Try parsing as delta-seconds. Per the Retry-After spec this must be
+  // digits only, so reject values like "5abc" that parseInt would accept.
+  const trimmed = value.trim();
+  if (/^\d+$/.test(trimmed)) {
+    return Number(trimmed) * 1000;
   }
 
   // Try parsing as HTTP-date (e.g., "Wed, 21 Oct 2015 07:28:00 GMT")
@@ -173,28 +177,29 @@ export function calculateRetryDelay(
 export function resolveRetryConfig(
   userConfig: IRetryConfig | false | undefined,
 ): IResolvedRetryConfig {
-  // If explicitly disabled, return disabled config
-  if (userConfig === false) {
+  // No retry config (undefined) or explicit `false` => retries are off.
+  // Return a fresh object with a cloned retryMethods array so callers can
+  // never mutate DEFAULT_RETRY_CONFIG or its array.
+  if (!userConfig) {
     return {
       ...DEFAULT_RETRY_CONFIG,
       enabled: false,
+      retryMethods: [...DEFAULT_RETRY_CONFIG.retryMethods],
     };
   }
 
-  // If undefined or empty, use defaults
-  if (!userConfig) {
-    return DEFAULT_RETRY_CONFIG;
-  }
-
-  // Merge user config with defaults
+  // Providing a retry config object opts you in, unless `enabled: false` is set.
+  const retryMethods = userConfig.retryMethods ?? DEFAULT_RETRY_CONFIG.retryMethods;
   return {
-    enabled: userConfig.enabled ?? DEFAULT_RETRY_CONFIG.enabled,
+    enabled: userConfig.enabled ?? true,
     maxRetries: userConfig.maxRetries ?? DEFAULT_RETRY_CONFIG.maxRetries,
     retryDelay: userConfig.retryDelay ?? DEFAULT_RETRY_CONFIG.retryDelay,
     backoffMultiplier: userConfig.backoffMultiplier ?? DEFAULT_RETRY_CONFIG.backoffMultiplier,
     maxDelay: userConfig.maxDelay ?? DEFAULT_RETRY_CONFIG.maxDelay,
     retryCondition: userConfig.retryCondition ?? DEFAULT_RETRY_CONFIG.retryCondition,
     respectRetryAfter: userConfig.respectRetryAfter ?? DEFAULT_RETRY_CONFIG.respectRetryAfter,
-    retryMethods: userConfig.retryMethods ?? DEFAULT_RETRY_CONFIG.retryMethods,
+    // Normalize to uppercase so lowercase user methods match the interceptor,
+    // which uppercases the request method.
+    retryMethods: retryMethods.map((m) => m.toUpperCase()),
   };
 }

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -6,9 +6,16 @@ import { AxiosError } from 'axios';
 export const RETRYABLE_STATUS_CODES = [408, 429, 500, 502, 503, 504];
 
 /**
- * Default HTTP methods that are safe to retry
+ * Default HTTP methods that are safe to retry.
+ * Frozen so the shared DEFAULT_RETRY_CONFIG array cannot be mutated by consumers.
  */
-const DEFAULT_RETRY_METHODS = ['GET', 'HEAD', 'OPTIONS', 'PUT', 'DELETE'];
+const DEFAULT_RETRY_METHODS: readonly string[] = Object.freeze([
+  'GET',
+  'HEAD',
+  'OPTIONS',
+  'PUT',
+  'DELETE',
+]);
 
 /**
  * Function type for custom retry condition evaluation
@@ -27,7 +34,8 @@ export interface IRetryConfig {
   enabled?: boolean;
 
   /**
-   * Maximum number of retry attempts. Defaults to 3.
+   * Maximum number of retries after the initial request. Defaults to 3
+   * (i.e. up to 4 total attempts).
    */
   maxRetries?: number;
 
@@ -105,7 +113,10 @@ export const DEFAULT_RETRY_CONFIG: IResolvedRetryConfig = Object.freeze({
   maxDelay: 30000,
   retryCondition: defaultRetryCondition,
   respectRetryAfter: true,
-  retryMethods: DEFAULT_RETRY_METHODS,
+  // Cast keeps the public IResolvedRetryConfig.retryMethods type as string[];
+  // the array is frozen at runtime and resolveRetryConfig always clones it
+  // before returning, so callers receive a mutable copy.
+  retryMethods: DEFAULT_RETRY_METHODS as string[],
 });
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,22 +22,7 @@
   dependencies:
     escape-string-regexp "^2.0.0"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@7.12.11":
-  version "7.12.11"
-  resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz"
-  integrity sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==
-  dependencies:
-    "@babel/highlight" "^7.10.4"
-
-"@babel/code-frame@^7.22.10":
-  version "7.22.10"
-  resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.10.tgz"
-  integrity sha512-/KKIMG4UEL35WmI9OlvMhurwtytjvXoFcGNrOvyG9zIzA8YmPjVtIZUf7b05+TPO7G7/GEmLHDaoCgACHl9hhA==
-  dependencies:
-    "@babel/highlight" "^7.22.10"
-    chalk "^2.4.2"
-
-"@babel/code-frame@^7.27.1":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.22.10", "@babel/code-frame@^7.27.1":
   version "7.27.1"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz"
   integrity sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==
@@ -45,6 +30,13 @@
     "@babel/helper-validator-identifier" "^7.27.1"
     js-tokens "^4.0.0"
     picocolors "^1.1.1"
+
+"@babel/code-frame@7.12.11":
+  version "7.12.11"
+  resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz"
+  integrity sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==
+  dependencies:
+    "@babel/highlight" "^7.10.4"
 
 "@babel/compat-data@^7.22.9":
   version "7.22.9"
@@ -155,7 +147,7 @@
     "@babel/traverse" "^7.22.10"
     "@babel/types" "^7.22.10"
 
-"@babel/highlight@^7.10.4", "@babel/highlight@^7.22.10":
+"@babel/highlight@^7.10.4":
   version "7.22.10"
   resolved "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.10.tgz"
   integrity sha512-78aUtVcT7MUscr0K5mIEnkwxPE0MaxkR5RxRwuHaQ+JuU5AmTPhY+do2mdzVTnIJJpyBglql2pehuBIWHug+WQ==
@@ -3091,11 +3083,6 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@~2.3.2:
-  version "2.3.2"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
-  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
-
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz"
@@ -3343,7 +3330,14 @@ globals@^11.1.0:
   resolved "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
-globals@^13.6.0, globals@^13.9.0:
+globals@^13.6.0:
+  version "13.21.0"
+  resolved "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz"
+  integrity sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==
+  dependencies:
+    type-fest "^0.20.2"
+
+globals@^13.9.0:
   version "13.21.0"
   resolved "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz"
   integrity sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==
@@ -6960,12 +6954,7 @@ yargs-parser@^18.1.2:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^20.2.2:
-  version "20.2.9"
-  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz"
-  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
-
-yargs-parser@^20.2.3:
+yargs-parser@^20.2.2, yargs-parser@^20.2.3:
   version "20.2.9"
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1274,6 +1274,13 @@ axios@0.27.2:
     follow-redirects "^1.14.9"
     form-data "^4.0.0"
 
+axios-retry@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.npmjs.org/axios-retry/-/axios-retry-4.5.0.tgz"
+  integrity sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==
+  dependencies:
+    is-retry-allowed "^2.2.0"
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
@@ -3847,6 +3854,11 @@ is-regex@^1.1.4:
   dependencies:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
+
+is-retry-allowed@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz"
+  integrity sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==
 
 is-shared-array-buffer@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Summary

Adds **opt-in** HTTP retry support to the SDK for transient failures, built on the [`axios-retry`](https://github.com/softonic/axios-retry) library. **Retries are off by default** — existing callers see no behavior change unless they pass a `retry` config.

- Opt-in: retries are disabled unless a `retry` (or `pdpRetry`) config object is provided; `retry: false` keeps them off.
- Exponential backoff with jitter, capped by `maxDelay`; honors `Retry-After` (delay-seconds or HTTP-date) on `429`.
- Retries on network errors and status codes `408, 429, 500, 502, 503, 504`.
- Separate config per surface: `retry` (REST API) and `pdpRetry` (PDP/OPA, falls back to `retry`).
- PDP/OPA additionally retry `POST` (check operations are idempotent); the REST API never retries `POST`.
- PDP/OPA use dedicated internal axios instances, so POST retries are never installed on the shared REST client (no double-writes).

## What kind of change does this PR introduce?

Feature (with tests and docs). Linear: PER-13890.

## Current behavior

The SDK issues HTTP requests to the Permit REST API and to the PDP with no automatic retry. Any transient failure — a network error, a `429` rate-limit, or a `5xx` — surfaces to the caller immediately on the first attempt.

## New behavior

Opt-in retry is wired onto the SDK's HTTP clients via `axios-retry`, driven by the SDK's own delay/condition policy.

- **Opt-in default** — `retry`/`pdpRetry` are unset by default, so retries are off and existing callers are unaffected. Providing a `retry` config object turns them on (3 attempts, exponential backoff by default); `retry: false` or `enabled: false` keeps them off.
- **Config** (`src/config.ts`) — two optional fields on `IPermitConfig`:
  - `retry?: IRetryConfig | false` — REST API client.
  - `pdpRetry?: IRetryConfig | false` — PDP/OPA clients; falls back to `retry` when omitted.
- **Policy** (`src/utils/retry.ts`) — `resolveRetryConfig`, `calculateRetryDelay` (exponential backoff + jitter, `maxDelay` cap, `Retry-After`), `parseRetryAfter`, and `RETRYABLE_STATUS_CODES`. The retry condition is "network error or retryable status," filtered by the configured methods (normalized to uppercase).
- **Mechanics** (`src/utils/retry-interceptor.ts`) — a thin adapter that configures `axios-retry` on an instance from the resolved policy (`retries`, `retryCondition`, `retryDelay`, `shouldResetTimeout`, `onRetry` logging). `axios-retry` owns retry counting, re-dispatch, per-attempt timeout reset, and request-abort handling.
- **Wiring** — `src/index.ts` installs retry on the REST API instance; `src/enforcement/enforcer.ts` installs it on dedicated PDP and OPA instances with `POST` added to the retried methods.
- **Behavioral notes**
  - When enabled, PDP/OPA retry `POST` (idempotent checks); the REST API does not retry `POST`, so non-idempotent writes are never repeated.
  - A custom `axiosInstance` applies to the REST API only; PDP and OPA use dedicated internal axios instances.
- **New exports** (`src/index.ts`): `IRetryConfig`, `RetryConditionFn`, `RETRYABLE_STATUS_CODES`. All additions are optional/additive — existing config and call sites are unchanged.

## Files changed

- `src/utils/retry.ts`, `src/utils/retry-interceptor.ts` — new (config/delay policy + `axios-retry` adapter)
- `src/config.ts` — `retry` / `pdpRetry` config fields
- `src/index.ts` — install REST retry + re-exports
- `src/enforcement/enforcer.ts` — dedicated PDP/OPA instances + retry (`POST` enabled for PDP/OPA)
- `src/tests/unit/retry.spec.ts`, `src/tests/unit/retry-interceptor.spec.ts` — unit + behavior tests
- `README.md` — retry configuration documentation
- `package.json` / `yarn.lock` — add `axios-retry`

## Test summary

- **Unit tests** for the config/delay/parse helpers (`resolveRetryConfig` opt-in semantics, `calculateRetryDelay`, `parseRetryAfter`).
- **Behavior tests** through real axios instances: REST and PDP use separate instances, REST does not retry `POST` while PDP does, retry count, non-retryable status, disallowed method, disabled path, `Retry-After` end-to-end, and success-after-retry.
- Unit specs run in CI via the `test:unit` script (`run-s test:*`).
