### PR TITLE
fix: add missing extends field to Role types

### DIFF
--- a/src/openapi/types/resource-role-create.ts
+++ b/src/openapi/types/resource-role-create.ts
@@ -53,6 +53,12 @@ export interface ResourceRoleCreate {
    */
   attributes?: object;
   /**
+   * list of role keys that define what roles this role extends. In other words: this role will automatically inherit all the permissions of the given roles in this list.
+   * @type {Array<string>}
+   * @memberof ResourceRoleCreate
+   */
+  extends?: Array<string>;
+  /**
    *
    * @type {GrantedTo1}
    * @memberof ResourceRoleCreate

--- a/src/openapi/types/resource-role-read.ts
+++ b/src/openapi/types/resource-role-read.ts
@@ -47,6 +47,12 @@ export interface ResourceRoleRead {
    */
   attributes?: object;
   /**
+   * list of role keys that define what roles this role extends. In other words: this role will automatically inherit all the permissions of the given roles in this list.
+   * @type {Array<string>}
+   * @memberof ResourceRoleRead
+   */
+  extends?: Array<string>;
+  /**
    *
    * @type {GrantedTo2}
    * @memberof ResourceRoleRead

--- a/src/openapi/types/resource-role-update.ts
+++ b/src/openapi/types/resource-role-update.ts
@@ -47,6 +47,12 @@ export interface ResourceRoleUpdate {
    */
   attributes?: object;
   /**
+   * list of role keys that define what roles this role extends. In other words: this role will automatically inherit all the permissions of the given roles in this list.
+   * @type {Array<string>}
+   * @memberof ResourceRoleUpdate
+   */
+  extends?: Array<string>;
+  /**
    *
    * @type {GrantedTo1}
    * @memberof ResourceRoleUpdate

--- a/src/openapi/types/role-create.ts
+++ b/src/openapi/types/role-create.ts
@@ -53,6 +53,12 @@ export interface RoleCreate {
    */
   attributes?: object;
   /**
+   * list of role keys that define what roles this role extends. In other words: this role will automatically inherit all the permissions of the given roles in this list.
+   * @type {Array<string>}
+   * @memberof RoleCreate
+   */
+  extends?: Array<string>;
+  /**
    *
    * @type {GrantedTo1}
    * @memberof RoleCreate

--- a/src/openapi/types/role-read.ts
+++ b/src/openapi/types/role-read.ts
@@ -47,6 +47,12 @@ export interface RoleRead {
    */
   attributes?: object;
   /**
+   * list of role keys that define what roles this role extends. In other words: this role will automatically inherit all the permissions of the given roles in this list.
+   * @type {Array<string>}
+   * @memberof RoleRead
+   */
+  extends?: Array<string>;
+  /**
    *
    * @type {GrantedTo}
    * @memberof RoleRead

--- a/src/openapi/types/role-update.ts
+++ b/src/openapi/types/role-update.ts
@@ -47,6 +47,12 @@ export interface RoleUpdate {
    */
   attributes?: object;
   /**
+   * list of role keys that define what roles this role extends. In other words: this role will automatically inherit all the permissions of the given roles in this list.
+   * @type {Array<string>}
+   * @memberof RoleUpdate
+   */
+  extends?: Array<string>;
+  /**
    *
    * @type {GrantedTo1}
    * @memberof RoleUpdate

--- a/src/tests/unit/role-extends.spec.ts
+++ b/src/tests/unit/role-extends.spec.ts
@@ -1,0 +1,36 @@
+import test from 'ava';
+
+import {
+  ResourceRoleCreate,
+  ResourceRoleRead,
+  ResourceRoleUpdate,
+  RoleCreate,
+  RoleRead,
+  RoleUpdate,
+} from '../../openapi/types';
+
+// Compile-time guard for the `extends` role-inheritance field on the six generated role types.
+// Removing `extends?: Array<string>` from any of them makes this file fail to compile under
+// `yarn build` (build:types -> tsc): TS2322 on the create/update object literals (excess property)
+// and TS2339 on the read member access. The runtime assertions below exist only so the test:unit
+// ava glob exercises the file; the substantive check is that it type-checks.
+const roleCreate: RoleCreate = { key: 'editor', name: 'Editor', extends: ['viewer'] };
+const roleUpdate: RoleUpdate = { extends: ['viewer'] };
+const roleReadExtends: Array<string> | undefined = ({} as RoleRead).extends;
+
+const resourceRoleCreate: ResourceRoleCreate = {
+  key: 'editor',
+  name: 'Editor',
+  extends: ['viewer'],
+};
+const resourceRoleUpdate: ResourceRoleUpdate = { extends: ['viewer'] };
+const resourceRoleReadExtends: Array<string> | undefined = ({} as ResourceRoleRead).extends;
+
+test('Role and ResourceRole types expose the `extends` inheritance field', (t) => {
+  t.deepEqual(roleCreate.extends, ['viewer']);
+  t.deepEqual(roleUpdate.extends, ['viewer']);
+  t.is(roleReadExtends, undefined);
+  t.deepEqual(resourceRoleCreate.extends, ['viewer']);
+  t.deepEqual(resourceRoleUpdate.extends, ['viewer']);
+  t.is(resourceRoleReadExtends, undefined);
+});


### PR DESCRIPTION

- **What kind of change does this PR introduce?**

Bug fix. Adds the missing `extends` field to the generated Role and ResourceRole types so SDK consumers can use role inheritance with type safety.

- **What is the current behavior?** (You can also link to an open issue here)

The Permit API and the OpenAPI spec define `extends` (`Array<string>`) on the role schemas, and the API returns it, but it is missing from the generated TypeScript types. Consumers cannot set or read role inheritance without a type error:

```ts
permit.api.roles.create({ key: 'editor', name: 'Editor', extends: ['viewer'] });
// 'extends' does not exist in type 'RoleCreate'
const role = await permit.api.roles.get('editor');
role.extends; // Property 'extends' does not exist on type 'RoleRead'
```

The same gap affects the resource-scoped roles (`permit.api.resourceRoles.*`).

This replaces the earlier version of the PR, which bundled unrelated changes. See "Other information".

- **What is the new behavior (if this is a feature change)?**

`extends?: Array<string>` is added to the six generated role interfaces:

- `RoleCreate`, `RoleRead`, `RoleUpdate`
- `ResourceRoleCreate`, `ResourceRoleRead`, `ResourceRoleUpdate`

The member matches the generator output after the repo's prettier post-processing: the live-spec doc comment, positioned between `attributes` and `granted_to`, so a future regeneration reproduces this exact `extends` member as a no-op. A full regeneration would also pick up unrelated spec drift on these schemas, such as updated `granted_to` typing and the `v1compat_*` fields; that re-baseline is tracked separately in #130. A unit test (`src/tests/unit/role-extends.spec.ts`) pins the field on all six types for create, update, and read; it fails to compile if any of the additions is reverted.

| Check | Before | After |
| --- | --- | --- |
| `RoleCreate`/`ResourceRoleCreate` accept `extends` | type error | compiles |
| `RoleRead.extends` / `ResourceRoleRead.extends` typed | not present | `Array<string>` |
| `RoleUpdate`/`ResourceRoleUpdate` accept `extends` | type error | compiles |
| `yarn build` | pass | pass |
| `yarn lint` | pass (0 errors) | pass (0 errors) |
| `yarn test:unit` | n/a (no test) | 49 passed, incl. `role-extends` |
| revert the six additions | — | `role-extends.spec.ts` fails to compile (4 assignability + 6 member-access errors) |

- **Other information**:

Scope. This PR is now only the `extends` type addition and its test. The earlier version also rewrote `src/logger.ts` (pino transport) and bumped several runtime dependencies with a large lockfile change. Both are unrelated to `extends`, were flagged in review, and are dropped here.

On hand-editing a generated file. The review suggested running `yarn generate-openapi-client` and committing the regenerated output instead of a hand-edit. That path is currently broken. The pinned generator (6.2.1) cannot read the live spec, which is now OpenAPI 3.1.0, so it regenerates an all-`any`, type-erased client (247 of 319 type files) and still exits 0. Regenerating today would replace the whole typed client with `any`, which is worse than a missing field. I reported that separately in #130 with a reproduction and options. Targeted hand-edits to `src/openapi/types/*.ts` are accepted practice in this repo: be9b59a (`Add created_at and updated_at to userRead schema`) added two fields to `user-read.ts` by hand, and c502f4e (`add 2 more checks for derived roles settings`) added an import and a field to `derived-role-rule-create.ts`, both single-file edits to files carrying the same "Do not edit the class manually" header. Until #130 is fixed, hand-adding the field is the lowest-risk option, and because it matches generator output it folds into the next clean regeneration as a no-op. The new test guards against silent loss in the meantime.

Not included here, on purpose: a full client regeneration (blocked by #130), the `v1compat_*` fields, which the spec also places on most of these schemas but which the committed client predates (a separate missing-field gap, intentionally out of scope here), and any change to non-role types.

