### PR TITLE
fix(build): reduce published package size by fixing files field

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,9 +101,8 @@
   },
   "files": [
     "build",
-    "!**/*.spec.*",
-    "!**/*.json",
-    "CHANGELOG.md",
+    "!build/tests",
+    "!build/**/*.spec.*",
     "LICENSE",
     "README.md"
   ],


### PR DESCRIPTION
- **What kind of change does this PR introduce?**

  Bug fix (build / packaging). It removes compiled **test fixtures** that are still shipped in the
  published `permitio` npm package.

- **What is the current behavior?** (link: #90)

  The `files` allowlist in `package.json` already scopes the published package to `build/` (so the
  dev tree — `src/`, `docs/`, `.github/`, etc. — is **not** shipped), and `!**/*.spec.*` already
  excludes compiled spec files. However, the **non-spec** test fixtures compiled into
  `build/tests/` — `fixtures.js`, `fixtures.mjs`, `fixtures.d.ts`, and their source maps — are not
  `.spec.*` files, so they slip past the negation and end up in the tarball. The field also lists a
  `CHANGELOG.md` that does not exist in the repo (npm warns on it) and uses an overly broad
  `!**/*.json` negation that is incorrect for an allowlist.

  ```json
  "files": ["build", "!**/*.spec.*", "!**/*.json", "CHANGELOG.md", "LICENSE", "README.md"]
  ```

- **What is the new behavior (if this is a feature change)?**

  The `files` field is scoped to exclude the compiled test tree and drop the dead/over-broad entries:

  ```json
  "files": ["build", "!build/tests", "!build/**/*.spec.*", "LICENSE", "README.md"]
  ```

  Verified with `npm pack --dry-run` (Node 20). The published tarball no longer contains any
  `build/tests/` or `*.spec.*` artifacts, while the entire public API surface is preserved:

  | Metric | Before (current `main`) | After |
  |---|---|---|
  | files | 1772 | **1767** |
  | packed (tarball) | 6062 KB | **5730 KB** (−332 KB) |
  | unpacked | ~89 MB | ~84 MB (−4.9 MB) |

  Removed (exactly 5 files): `build/tests/fixtures.{d.ts,js,js.map,mjs,mjs.map}`. Still present and
  verified: `build/index.js`, `build/index.mjs`, `build/index.d.ts`, `LICENSE`, `README.md`,
  `package.json`. No non-test `build/` output is dropped.

- **Other information**:

  <details><summary>Reproducible before/after evidence</summary>

  ```
  # after (this branch):
  npm pack --dry-run --json --ignore-scripts --foreground-scripts=false
  #   entryCount: 1767   size: 5730.4 KB   unpackedSize: 86321.0 KB

  # before (base main package.json, same build output):
  #   entryCount: 1772   size: 6062.1 KB   unpackedSize: 91359.1 KB

  # delta: -5 files (build/tests/fixtures.*), -331.7 KB packed, -5038 KB unpacked
  # forbidden patterns in tarball after: src/=0 docs/=0 .github/=0 yarn.lock=0 *.spec.*=0 build/tests/=0
  ```
  </details>

  **What's NOT in this PR:** no dependency changes, no `tsconfig`/`tsup`/build-script changes, no
  `CHANGELOG.md` addition or release-tooling wiring. A cleaner long-term follow-up — scoping `tsup`'s
  `entry` so `src/tests/**` never compiles into `build/` at all — is tracked separately.

  The `security/snyk (permit)` check ERRORs on this PR; it is an external/integration issue on fork
  PRs (this PR changes no dependencies) and is unrelated to the change. A maintainer re-run/waiver
  would clear it.

  Fixes #90
