### PR TITLE
fix(build): add declaration maps for better editor navigation

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "moduleResolution": "node",
     "module": "commonjs",
     "declaration": true,
+    "declarationMap": true,
     "inlineSourceMap": true,
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
     "resolveJsonModule": true /* Include modules imported with .json extension. */,


### PR DESCRIPTION
## Summary

Enable TypeScript declaration maps (`declarationMap: true`) to fix "Go to Definition" navigation in editors like VS Code.

## Problem

As reported in #77, using "Go to Definition" on SDK methods (e.g., `permit.api.roles.create`) navigates to compiled JavaScript without type information, rather than to the typed declaration files. This makes it impossible to inspect parameter types like `RoleCreate` or return types like `RoleRead` through normal editor navigation.

## Solution

Added `declarationMap: true` to `tsconfig.json`. This generates `.d.ts.map` files alongside the existing `.d.ts` declarations during the `tsc --emitDeclarationOnly` build step. These map files enable editors to properly resolve "Go to Definition" and "Go to Type Definition" to the typed declarations.

## Changes

- `tsconfig.json` — Added `declarationMap: true` compiler option

## Testing

- `yarn lint` passes
- `yarn build:types` generates `.d.ts.map` files alongside `.d.ts` files (verified: `build/index.d.ts.map`, `build/api/roles.d.ts.map`, etc.)
- Declaration maps are automatically included in the published package via the existing `build` entry in the `files` field

## Backwards Compatibility

No breaking changes. Declaration maps are additive — they only improve editor DX for SDK consumers. Consumers that don't use TypeScript or don't rely on "Go to Definition" are unaffected.

**Note:** This PR addresses the declaration map portion of #77. The tsconfig target update (`es2017` → `ES2022`) mentioned in the issue is a separate change that would affect the minimum supported Node version and should be discussed separately.

## Checklist

- [x] `yarn lint` passes
- [x] `yarn build:types` succeeds with `.d.ts.map` output
- [x] No changes to `src/openapi/` (auto-generated)

Refs #77