### PR TITLE
fix(ci): replace sed version bump with npm version to prevent script corruption

### DIFF
--- a/.github/workflows/node_sdk_publish.yaml
+++ b/.github/workflows/node_sdk_publish.yaml
@@ -83,9 +83,14 @@ jobs:
           
       - name: Bump version at package.json
         run: |
-          sed -i "s/\"version\": \".*\"/\"version\": \"${{ github.event.release.tag_name }}\"/" package.json
-          cat package.json
-      
+          # Bump only the top-level "version" field. npm is JSON-aware (unlike the
+          # previous greedy sed, which also rewrote scripts.version); no git
+          # tag/commit is created, re-runs on the same version are tolerated, and
+          # the "version" lifecycle script (standard-version) is skipped.
+          npm version "${{ github.event.release.tag_name }}" --no-git-tag-version --allow-same-version --ignore-scripts
+          # Fail fast if the bump ever corrupts the scripts.version lifecycle hook again (the original #89 bug).
+          node -e "if (require('./package.json').scripts.version !== 'standard-version') { console.error('scripts.version was corrupted by the version bump'); process.exit(1); }"
+
       - name: Publish package to NPM
         run: |
           if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "cov:check": "nyc report && nyc check-coverage --lines 100 --functions 100 --branches 100",
     "docs": "typedoc",
     "docs:watch": "typedoc --watch",
-    "version": "2.5.2",
+    "version": "standard-version",
     "reset-hard": "git clean -dfx && git reset --hard && yarn",
     "prepare": "npm run build && husky install",
     "prepare-release": "run-s reset-hard test cov:check doc:html version doc:publish",


### PR DESCRIPTION
- **What kind of change does this PR introduce?**

  Bug fix (CI / release tooling).

- **What is the current behavior?** (link: #89)

  The publish workflow (`.github/workflows/node_sdk_publish.yaml`) bumps the package version before
  publishing with a greedy `sed`:

  ```
  sed -i "s/\"version\": \".*\"/\"version\": \"${{ github.event.release.tag_name }}\"/" package.json
  ```

  This regex matches **every** `"version":` key in `package.json`, not just the top-level field. The
  `scripts` block contains `"version": "standard-version"` (a `standard-version` lifecycle hook
  invoked by `prepare-release`: `run-s reset-hard test cov:check doc:html version doc:publish`). The
  `sed` run overwrites that script with the release version string. The corruption already happened
  (introduced in commit `2abe31f`) and is **still live on `main`** today — `scripts.version` is
  `"2.5.2"` instead of `"standard-version"`, so the `version` step of `prepare-release` is broken.

- **What is the new behavior (if this is a feature change)?**

  The bump step uses npm's JSON-aware tooling, which only mutates the top-level `version` field:

  ```
  npm version "${{ github.event.release.tag_name }}" --no-git-tag-version --allow-same-version --ignore-scripts
  ```
  - `--no-git-tag-version` — no commit/tag created in CI.
  - `--ignore-scripts` — does not fire the `version` lifecycle script (`standard-version`) during the bump.
  - `--allow-same-version` — tolerates re-runs / a tag equal to the current version.

  `package.json`'s `scripts.version` is also restored from the corrupted `"2.5.2"` back to
  `"standard-version"`, and a one-line post-bump assertion in the same step fails the release if
  `scripts.version` is ever clobbered again. This matches the fix suggested in #89.

  For the repo's bare-semver release tags the bump is equivalent to the old `sed`; note `npm version`
  additionally strips a stray leading `v` and validates semver (failing fast) where `sed` wrote the
  tag verbatim — a small improvement, not a behaviour change for current tags.

- **Other information**:

  <details><summary>Reproduced before/after (same input package.json, tag <code>9.9.9</code>)</summary>

  ```
  # input: top-level version = 2.7.5 , scripts.version = "standard-version"

  # (A) old sed  → corrupts BOTH:
  sed -i 's/"version": ".*"/"version": "9.9.9"/' package.json
    line 3:  "version": "9.9.9"
    line 50: "version": "9.9.9"          # scripts.version destroyed

  # (B) new npm version  → top-level only:
  npm version 9.9.9 --no-git-tag-version --allow-same-version --ignore-scripts
    line 3:  "version": "9.9.9"
    line 50: "version": "standard-version"   # preserved
  # diff vs input: only the top-level version changed; no git tag/commit; no lifecycle script fired
  ```
  </details>

  **What's NOT in this PR:** no broader rewrite of the publish workflow, no `standard-version`
  automated-release wiring, no dependency changes, no source changes. (A separate, unrelated issue:
  `prepare-release` also references `doc:html`/`doc:publish` scripts that aren't defined — out of
  scope here.)

  The `security/snyk (permit)` check shows ERROR; this is an external/integration issue on fork PRs
  (this PR adds no dependencies and changes only CI config + a script string). A maintainer re-run or
  waiver would clear it.

  Fixes #89
