### PR TITLE
Add missing roles field to getUserPermissions types

### DIFF
--- a/src/enforcement/interfaces.ts
+++ b/src/enforcement/interfaces.ts
@@ -147,6 +147,7 @@ export interface AllTenantsResponse {
 
 interface TenantPermissions {
   permissions: string[];
+  roles?: string[];
   tenant?: {
     key: string;
     attributes: {
@@ -157,6 +158,7 @@ interface TenantPermissions {
 
 interface ResourcePermissions {
   permissions: string[];
+  roles?: string[];
   resource?: {
     type: string;
     key: string;


### PR DESCRIPTION
## Summary
- Adds `roles?: string[]` to `TenantPermissions` and `ResourcePermissions` interfaces in `src/enforcement/interfaces.ts`
- The PDP returns a `roles` array in `getUserPermissions` responses, but the SDK types were missing this field, forcing users to use `as any` type assertions

Fixes PER-14323
