### PR TITLE
fix(build): shrink published package from ~202 MB to ~3.5 MB (PER-15197)

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,9 +100,10 @@
     "typescript": "^4.6.4"
   },
   "files": [
-    "build",
-    "!**/*.spec.*",
-    "!**/*.json",
+    "build/**/*.d.ts",
+    "build/index.js",
+    "build/index.mjs",
+    "!build/tests/**",
     "CHANGELOG.md",
     "LICENSE",
     "README.md"

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -5,7 +5,12 @@ export default defineConfig({
   format: ['cjs', 'esm'],
   dts: false,
   splitting: false,
-  sourcemap: true,
+  // Source maps are intentionally not emitted: they are not used by the test
+  // suite and previously shipped ~77 MB of .map files in the published package
+  // (see PER-15197). The published artifact is the self-contained build/index.*
+  // bundle only; per-file outputs below exist solely so the test suite can
+  // import internal modules by relative path.
+  sourcemap: false,
   clean: true,
   outDir: 'build',
   target: 'node16',


### PR DESCRIPTION
## Summary

The `permitio` npm package size exploded in **v2.7.5** — from **7.82 MB (v2.7.2)** to **~202 MB (v2.7.5)** — breaking a customer's AWS Lambda deploy (exceeds the code-size limit). This PR brings the published package down to **~3.5 MB unpacked / 195 KB packed** with zero functional changes.

Fixes **PER-15197**. Reported by a customer (Matthew Karges) in #support; their workaround was pinning to v2.7.2.

Closes #90 (published package contains many unnecessary files).

## Root cause

v2.7.5's "hybrid build" (PR #118, commit `2cdc9ef`) switched from `tsc` to `tsup` but the config caused the **entire per-file `build/` tree to be published**:

```ts
entry: ['src/**/*.ts'],   // every source file (incl. all tests + ~300 openapi type files) is its own entry
format: ['cjs', 'esm'],   // every file emitted twice (.js + .mjs)
splitting: false,         // no shared chunks -> each entry inlines its WHOLE internal import graph
sourcemap: true,          // a .map for every output file
```

With `splitting: false` + a per-file entry glob, the large generated `src/openapi` client got duplicated in full into every output bundle, then multiplied by two formats and a `.map` per file. The published tarball also still contained the test specs.

Measured breakdown of the bloat: **77 MB of source maps (708 `.map` files)**, `build/api` 62 MB, `build/openapi` 22 MB, test specs ~109 MB.

## The fix

The published artifact only needs the **self-contained `build/index.js` / `build/index.mjs` bundles** (verified: 0 relative imports; only `axios`/`lodash`/`pino`/`url-parse` externalized, all declared `dependencies`) plus the type declarations. The per-file outputs exist **solely so the test suite can import internal modules by relative path** (`require('../../api/api-client')`, `../../enforcement/enforcer`, `../../index`), so they must keep being built — they just don't need to be published.

**`package.json` — `files`:** publish only the bundle + types instead of the whole `build/`:
```jsonc
"files": [
  "build/**/*.d.ts",
  "build/index.js",
  "build/index.mjs",
  "!build/tests/**",
  "CHANGELOG.md", "LICENSE", "README.md"
]
```

**`tsup.config.ts`:** `sourcemap: false` — maps are unused by the test suite and were ~77 MB of dead weight.

No source code changed; the hybrid ESM/CJS output is preserved.

## Results (`npm pack`)

| Metric | Before (v2.7.5) | After |
|---|---|---|
| Unpacked | **202 MB** (94 MB locally) | **3.5 MB** |
| Packed | 6.2 MB | **195 KB** |
| `.map` files | 708 | **0** |
| spec/test files | included (~109 MB) | **0** |

Smaller than the last known-good v2.7.2 (7.82 MB).

## Verification

- ✅ CJS consume: `require('./build/index.js')` → `Permit` instantiates; `.check`/`.api`/`.elements` present
- ✅ ESM consume: `import { Permit } from './build/index.mjs'` → same
- ✅ `npm pack`: 3.5 MB, only `index.js`/`index.mjs` + `.d.ts`; no maps, no tests
- ✅ Per-file build intact (`build/api/*.js`, `build/enforcement/*.js`, …); `yarn test` unaffected
- ✅ Module-import suite passes 6/6 (CJS + ESM relative-import tests)

## Follow-ups (post-merge)

- Cut a patch release (e.g. **2.7.6**)
- Notify the customer they can unpin from 2.7.2

## References

- Linear: PER-15197
- Slack: https://permit-io.slack.com/archives/C047AUNF1LY/p1782154288796939
- Regression introduced by: #118 (`create-hybrid-build`), commit `2cdc9ef`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

