### PR TITLE
ci: npm Trusted Publishing (OIDC) + mask Permit API key in logs

### DIFF
--- a/.github/workflows/node_sdk_publish.yaml
+++ b/.github/workflows/node_sdk_publish.yaml
@@ -61,10 +61,12 @@ jobs:
             https://api.permit.io/v2/api-key/${{ env.PROJECT_ID }}/${{ env.ENV_ID }} \
             -H 'Authorization: Bearer ${{ secrets.PROJECT_API_KEY }}')
 
-          # Extract the secret from the response which is the API_KEY of the new env
-          echo "ENV_API_KEY=$(echo "$response" | jq -r '.secret')" >> $GITHUB_ENV
-
-          echo "New env api key: $ENV_API_KEY"
+          # Extract the api key secret and register it for masking BEFORE writing
+          # it to the environment, so it is redacted everywhere in the logs
+          # (including the env-group dumps of every later step). Do not echo it.
+          ENV_API_KEY=$(echo "$response" | jq -r '.secret')
+          echo "::add-mask::$ENV_API_KEY"
+          echo "ENV_API_KEY=$ENV_API_KEY" >> "$GITHUB_ENV"
 
       - name: local PDP runnning
         env:

--- a/.github/workflows/node_sdk_publish.yaml
+++ b/.github/workflows/node_sdk_publish.yaml
@@ -10,17 +10,23 @@ env:
 jobs:
   publish_node_sdk:
     runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: read
+      id-token: write # Required for npm Trusted Publishing (OIDC)
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
-          token: ${{ secrets.NPM_TOKEN }}
-      
+
+      - name: Upgrade npm for Trusted Publishing
+        run: npm install -g npm@latest && npm --version
+
       - name: Set git user
         run: |
           git config --global user.email "eli@permit.io"
@@ -83,18 +89,26 @@ jobs:
           
       - name: Bump version at package.json
         run: |
-          sed -i "s/\"version\": \".*\"/\"version\": \"${{ github.event.release.tag_name }}\"/" package.json
+          # Use the release tag as the version, stripping any leading 'v'
+          # (e.g. 'v2.7.6' -> '2.7.6') so it is valid semver for npm.
+          VERSION=${{ github.event.release.tag_name }}
+          VERSION=${VERSION#v}
+          sed -i "s/\"version\": \".*\"/\"version\": \"$VERSION\"/" package.json
           cat package.json
-      
+
       - name: Publish package to NPM
         run: |
           if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
             echo "Publishing as a release candidate (rc)..."
-            yarn publish --access public --tag rc
+            npm publish --access public --tag rc
           else
             echo "Publishing as the latest release..."
-            yarn publish --access public
+            npm publish --access public
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # No NPM_TOKEN needed — authenticated via npm Trusted Publishing (OIDC),
+        # which requires the job's `id-token: write` permission above plus a
+        # Trusted Publisher configured on npmjs.com:
+        #   permitio/permit-node -> Settings -> Trusted Publishers
+        #   (workflow: node_sdk_publish.yaml, environment: production)
+        # Provenance attestations are generated automatically.
 


### PR DESCRIPTION
## Summary

Two related CI hardening changes to `.github/workflows/node_sdk_publish.yaml`:

1. **Switch npm auth to Trusted Publishing (OIDC), remove `NPM_TOKEN`** — refs **PER-15197**
2. **Mask the fetched Permit API key so it is no longer logged in cleartext** — fixes **PER-15241**

---

## 1. npm Trusted Publishing (OIDC)

Mirrors the approach just adopted in `permit-fe-sdk` ([d193a76](https://github.com/permitio/permit-fe-sdk/commit/d193a76e9f14788158ff8efb1a834528370ba5a5)).

### Why

The `2.7.6` release ([run 28086479788](https://github.com/permitio/permit-node/actions/runs/28086479788)) failed on publish with `Couldn't publish package: "https://registry.npmjs.org/permitio: Not found"`. That 404 is npm's response to an **unauthorized** publish — the long-lived `NPM_TOKEN` (last successful publish 2025-06-23, >1 year ago) had expired. Trusted Publishing removes the stored token: GitHub mints a short-lived OIDC credential per run that npm verifies against a configured Trusted Publisher.

### Changes

- Add `permissions: { contents: read, id-token: write }` (OIDC requires `id-token: write`)
- Run the job in the **`production`** environment (matches the npm Trusted Publisher config)
- Upgrade npm to latest at runtime (Trusted Publishing needs npm ≥ 11.5.1)
- Publish with **`npm publish`** instead of `yarn publish` — yarn classic doesn't support OIDC — and drop `NODE_AUTH_TOKEN`
- Strip a leading `v` from the release tag → `v2.7.6` becomes valid semver `2.7.6`
- Provenance attestations are generated automatically

The PDP integration-test flow (create env → run PDP → `yarn test` → delete env) is unchanged.

## 2. Mask fetched Permit API key (PER-15241)

The *Fetch API_KEY* step wrote the env api key to `$GITHUB_ENV` and echoed it directly, so it appeared in cleartext in the logs and in the env-group dump of every later step. Now the value is registered with `::add-mask::` **before** export and the explicit echo is removed, so it's redacted everywhere.

> Follow-up still required: **rotate `PROJECT_API_KEY`**, since it was exposed in prior run logs.

---

## ⚠️ Required before this can publish

A Trusted Publisher must be configured on npmjs.com (maintainer indicated this is done — please confirm it matches exactly):

- **Package:** `permitio` → Settings → Trusted Publishers → GitHub Actions
- **Owner:** `permitio` · **Repository:** `permit-node`
- **Workflow filename:** `node_sdk_publish.yaml`
- **Environment:** `production`

If the npm config names a different workflow file or environment, the OIDC claim won't match and publish will fail. (fe-sdk's workflow is `release.yml`; ours is `node_sdk_publish.yaml` — most likely field to be mismatched if copied.)

This repo has no `production` GitHub environment yet; referencing it creates it on first run with no protection rules.

## How to verify

1. Merge → create a GitHub Release tagged `2.7.6-rc.0`, labeled **Pre-release** → publishes `permitio@2.7.6-rc.0` under the `rc` dist-tag via OIDC (no token).
2. `npm view permitio@2.7.6-rc.0 dist.unpackedSize` → confirms the size fix (~3.5 MB) and that OIDC auth worked. Confirm the leaked key no longer appears in the run logs.
3. Promote with a `2.7.6` release labeled **Latest**.
4. After a green publish: delete the `NPM_TOKEN` repo secret and rotate `PROJECT_API_KEY`.

## Related

- Refs **PER-15197** (package-size fix)
- Fixes **PER-15241** (cleartext API-key logging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
