### PR TITLE
ci: simplify npm publish step for Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/node_sdk_publish.yaml
+++ b/.github/workflows/node_sdk_publish.yaml
@@ -99,14 +99,7 @@ jobs:
           cat package.json
 
       - name: Publish package to NPM
-        run: |
-          if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
-            echo "Publishing as a release candidate (rc)..."
-            npm publish --access public --tag rc
-          else
-            echo "Publishing as the latest release..."
-            npm publish --access public
-          fi
+        run: npm publish
         # No NPM_TOKEN needed — authenticated via npm Trusted Publishing (OIDC),
         # which requires the job's `id-token: write` permission above plus a
         # Trusted Publisher configured on npmjs.com:


### PR DESCRIPTION
## Summary
- Simplifies the `Publish package to NPM` step in `node_sdk_publish.yaml` to a single `npm publish` command.
- Removes the manual prerelease/`--tag rc` branching and the explicit `--access public` flag, relying on npm Trusted Publishing (OIDC) for authentication.

## Context
Follow-up to the migration to npm Trusted Publishing (PER-15197). Authentication is handled via the job's `id-token: write` permission plus a Trusted Publisher configured on npmjs.com — no `NPM_TOKEN` needed.

## Test plan
- [ ] Verify a release publishes successfully via the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)