### PR TITLE
fix(enforcer): send checkAllTenants payload and auth header correctly (PER-15318)

### DIFF
--- a/src/enforcement/enforcer.ts
+++ b/src/enforcement/enforcer.ts
@@ -362,18 +362,24 @@ export class Enforcer implements IEnforcer {
     context: Context = {}, // default to empty context if not provided
     sdk = 'node', // default to "node" if not provided
   ): Promise<TenantDetails[]> {
+    // checkAllTenants evaluates the request across ALL tenants, so the resource
+    // must NOT be pinned to a tenant. We normalize the string forms of user and
+    // resource to match check()'s input contract, but intentionally skip
+    // normalizeResource() because it injects config.multiTenancy.defaultTenant.
+    const input: ICheckInput = {
+      user: isString(user) ? { key: user } : user,
+      action,
+      resource: isString(resource) ? Enforcer.resourceFromString(resource) : resource,
+      context,
+    };
+
     try {
-      const response = await this.client.post<AllTenantsResponse>('/allowed/all-tenants', {
+      const response = await this.client.post<AllTenantsResponse>('allowed/all-tenants', input, {
         headers: {
           Authorization: `Bearer ${this.config.token}`,
           'X-Permit-Sdk-Language': sdk,
         },
-        params: {
-          user,
-          action,
-          resource,
-          context,
-        },
+        timeout: this.config.timeout,
       });
       return response.data.allowedTenants.map((item) => item.tenant);
     } catch (error) {

--- a/src/tests/unit/check-all-tenants.spec.ts
+++ b/src/tests/unit/check-all-tenants.spec.ts
@@ -1,0 +1,115 @@
+import test from 'ava';
+import { AxiosInstance, InternalAxiosRequestConfig } from 'axios';
+
+import { IResource, IUser, TenantDetails } from '../../enforcement/interfaces';
+
+// Reaches the private PDP (enforcer.client) axios instance so we can swap its
+// adapter and capture the outgoing request the SDK actually builds.
+interface PermitInternals {
+  enforcer: { client: AxiosInstance };
+  checkAllTenants: (
+    user: IUser | string,
+    action: string,
+    resource: IResource | string,
+  ) => Promise<TenantDetails[]>;
+}
+
+interface CapturedBody {
+  user: IUser;
+  action: string;
+  resource: IResource;
+  context: Record<string, unknown>;
+  // The old bug leaked these top-level keys into the request body.
+  headers?: unknown;
+  params?: unknown;
+}
+
+// Installs an adapter that records the request config and returns a canned
+// all-tenants response, so the call resolves without touching the network.
+function installCapturingAdapter(
+  instance: AxiosInstance,
+  tenants: Array<{ key: string }>,
+): { config: () => InternalAxiosRequestConfig } {
+  let captured: InternalAxiosRequestConfig;
+  instance.defaults.adapter = (config: InternalAxiosRequestConfig) => {
+    captured = config;
+    return Promise.resolve({
+      data: { allowedTenants: tenants.map((tenant) => ({ tenant })) },
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config,
+    });
+  };
+  return { config: () => captured };
+}
+
+async function newPermit(): Promise<PermitInternals> {
+  const { Permit } = await import('../../index');
+  return new Permit({
+    token: 'test-token',
+    pdp: 'http://localhost:7766',
+  }) as unknown as PermitInternals;
+}
+
+function parseBody(config: InternalAxiosRequestConfig): CapturedBody {
+  return typeof config.data === 'string' ? JSON.parse(config.data) : config.data;
+}
+
+test('checkAllTenants sends an authenticated, well-formed request (string forms)', async (t) => {
+  const permit = await newPermit();
+  const adapter = installCapturingAdapter(permit.enforcer.client, [{ key: 't1' }, { key: 't2' }]);
+
+  const tenants = await permit.checkAllTenants('elon', 'read', 'document:doc-1');
+
+  const config = adapter.config();
+
+  // Regression guard: the Authorization header is now actually sent as a header,
+  // not buried in the request body as it was before the fix.
+  t.is(config.headers.Authorization, 'Bearer test-token');
+  t.is(config.headers['X-Permit-Sdk-Language'], 'node');
+
+  const body = parseBody(config);
+  t.deepEqual(body, {
+    user: { key: 'elon' },
+    action: 'read',
+    resource: { type: 'document', key: 'doc-1' },
+    context: {},
+  });
+
+  // The old bug placed `headers` and `params` in the body.
+  t.is(body.headers, undefined);
+  t.is(body.params, undefined);
+
+  // All-tenants must never pin a default tenant on the resource.
+  t.is(body.resource.tenant, undefined);
+
+  t.deepEqual(tenants, [{ key: 't1' }, { key: 't2' }] as unknown as TenantDetails[]);
+});
+
+test('checkAllTenants accepts object forms for user and resource', async (t) => {
+  const permit = await newPermit();
+  const adapter = installCapturingAdapter(permit.enforcer.client, [{ key: 't1' }]);
+
+  const tenants = await permit.checkAllTenants({ key: 'elon' }, 'read', {
+    type: 'document',
+    key: 'doc-1',
+  });
+
+  const config = adapter.config();
+  t.is(config.headers.Authorization, 'Bearer test-token');
+  t.is(config.headers['X-Permit-Sdk-Language'], 'node');
+
+  const body = parseBody(config);
+  t.deepEqual(body, {
+    user: { key: 'elon' },
+    action: 'read',
+    resource: { type: 'document', key: 'doc-1' },
+    context: {},
+  });
+  t.is(body.headers, undefined);
+  t.is(body.params, undefined);
+  t.is(body.resource.tenant, undefined);
+
+  t.deepEqual(tenants, [{ key: 't1' }] as unknown as TenantDetails[]);
+});


### PR DESCRIPTION
- **What kind of change does this PR introduce?**

  Bug fix (SDK source). Standalone — based on `main`, independent of the test-modernization stack (#131–#133). Linear: PER-15318.

- **What is the current behavior?**

  `Enforcer.checkAllTenants` builds its request incorrectly:

  ```ts
  this.client.post('/allowed/all-tenants', {
    headers: { Authorization: `Bearer ${token}`, 'X-Permit-Sdk-Language': sdk },
    params: { user, action, resource, context },
  });
  ```

  `{ headers, params }` is passed as the axios POST **body** (the 2nd arg). Consequences:
  - The `Authorization` header is never sent as a request header → the PDP cannot authenticate the call.
  - `user / action / resource / context` are nested under `params` in the body instead of being the request payload.

  The method effectively cannot work against the PDP.

- **What is the new behavior?**

  Mirrors the correct `check()` mechanics:

  ```ts
  const input = { user: <normalized>, action, resource: <normalized>, context };
  this.client.post('allowed/all-tenants', input, {
    headers: { Authorization: `Bearer ${token}`, 'X-Permit-Sdk-Language': sdk },
    timeout: this.config.timeout,
  });
  ```

  - Body is the query payload; `headers`/`timeout` are the axios config (3rd) arg, so the auth header is actually sent.
  - `user`/`resource` string forms are normalized the same way `check()` does (`'elon'` → `{ key: 'elon' }`, `'document:doc-1'` → `{ type: 'document', key: 'doc-1' }`).
  - **No default-tenant injection** — an all-tenants query must not be pinned to a tenant (unlike `check()`, which injects `multiTenancy.defaultTenant`). Documented inline.
  - Signature, `sdk = 'node'` default, return mapping, and the existing `try/catch` are unchanged. Single-responsibility fix.

- **Other information**:

  **Tests**
  - [x] AVA regression test `src/tests/unit/check-all-tenants.spec.ts` — mocks the enforcer's PDP axios adapter and asserts: `Authorization: Bearer <token>` header is sent, body shape is the normalized payload, body contains no `headers`/`params` keys (the old bug), no tenant is injected, and the return maps to the tenant objects. Covers string and object input forms.
  - [x] Mocks the axios adapter (no network); `yarn build`/`tsc` + `yarn lint` clean.

  **Manual test plan**
  1. Point an SDK client at a running PDP. 2. `await permit.checkAllTenants('user-1', 'read', 'document:doc-1')`. 3. Confirm the PDP receives an authenticated request and returns the allowed tenants (previously 401/empty due to the missing auth header).

  **Adjacent issues noted (out of scope, not fixed here)**
  - `checkAllTenants`' `try/catch` only logs + rethrows (no `PermitConnectionError` wrapping like `check()`), and `index.ts` wraps the call in a second identical try/catch (double-logging on error). Candidates for a follow-up.

  **Note on the test stack:** PR #133 adds a Vitest *characterization* test asserting the current (buggy) body placement (flagged `TODO(PER-15318)`). Once this fix and that stack both land, that characterization test should be flipped to assert the corrected behavior — happy to do that on the #133 branch.

Generated with [Claude Code](https://claude.com/claude-code)
